### PR TITLE
Fix issue where frames cant be found when length is overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+* Fix issue where broadcasts to frames would fail if parent page has overwritten the window.length variable
+
 3.0.0
 =====
 

--- a/lib/framebus.js
+++ b/lib/framebus.js
@@ -215,6 +215,7 @@ function _hasOpener(frame) {
 
 function _broadcast(frame, payload, origin) {
   var i = 0;
+  var frameToBroadcastTo;
 
   try {
     frame.postMessage(payload, origin);
@@ -230,8 +231,8 @@ function _broadcast(frame, payload, origin) {
     // scope, it'll prevent us from looping through
     // all the frames. With this, we loop through
     // until there are no longer any frames
-    while (frame.frames[i]) {
-      _broadcast(frame.frames[i], payload, origin);
+    while (frameToBroadcastTo = frame.frames[i]) { // eslint-disable-line no-cond-assign
+      _broadcast(frameToBroadcastTo, payload, origin);
       i++;
     }
   } catch (_) { /* ignored */ }

--- a/lib/framebus.js
+++ b/lib/framebus.js
@@ -214,7 +214,7 @@ function _hasOpener(frame) {
 }
 
 function _broadcast(frame, payload, origin) {
-  var i;
+  var i = 0;
 
   try {
     frame.postMessage(payload, origin);
@@ -223,8 +223,16 @@ function _broadcast(frame, payload, origin) {
       _broadcast(frame.opener.top, payload, origin);
     }
 
-    for (i = 0; i < frame.frames.length; i++) {
+    // previously, our max value was frame.frames.length
+    // but frames.length inherits from window.length
+    // which can be overwritten if a developer does
+    // `var length = value;` outside of a function
+    // scope, it'll prevent us from looping through
+    // all the frames. With this, we loop through
+    // until there are no longer any frames
+    while (frame.frames[i]) {
       _broadcast(frame.frames[i], payload, origin);
+      i++;
     }
   } catch (_) { /* ignored */ }
 }


### PR DESCRIPTION
We use frame.frames.length to loop over the iframes, but frames.length inherits from window.length which can be overwritten if a developer does `var length = value;` outside of a function scope. This will prevent us from looping through all the frames. 

With this change, we loop through until there are no longer any frames in the frames list.

@mrak @braintree/team-dx 