### PR TITLE
Fix issue where postMessage could be called on non-existent window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+* Fix issue where framebus would error when trying to reply to a non-existent window/frame
+
 3.0.1
 =====
 

--- a/lib/framebus.js
+++ b/lib/framebus.js
@@ -125,7 +125,11 @@ function _unpackPayload(e) {
     replyEvent = payload.reply;
 
     payload.reply = function reply(data) { // eslint-disable-line consistent-return
-      var replyPayload = _packagePayload(replyEvent, [data], replyOrigin);
+      var replyPayload;
+
+      if (!replySource) { return false; }
+
+      replyPayload = _packagePayload(replyEvent, [data], replyOrigin);
 
       if (replyPayload === false) { return false; }
 

--- a/spec/unit/_unpackPayload.spec.js
+++ b/spec/unit/_unpackPayload.spec.js
@@ -37,4 +37,35 @@ describe('_unpackPayload', function () {
     expect(actual.args[1]).to.be.a('function');
     expect(actual.args[0]).to.equal('some data');
   });
+
+  it('the source should postMessage the payload to the origin when reply is called', function () {
+    var fakeSource = {
+      postMessage: this.sandbox.stub()
+    };
+    var reply = '123129085-4234-1231-99887877';
+    var args = ['some data'];
+    var actual = this.bus._unpackPayload({
+      source: fakeSource,
+      origin: 'origin',
+      data: messagePrefix + JSON.stringify({event: 'event name', reply: reply, args: args})
+    });
+
+    actual.reply({});
+
+    expect(fakeSource.postMessage).to.be.calledOnce;
+    expect(fakeSource.postMessage).to.be.calledWith(this.sandbox.match.string, 'origin');
+  });
+
+  it('the source should not attempt to postMessage the payload to the origin if no source available', function () {
+    var reply = '123129085-4234-1231-99887877';
+    var args = ['some data'];
+    var actual = this.bus._unpackPayload({
+      origin: 'origin',
+      data: messagePrefix + JSON.stringify({event: 'event name', reply: reply, args: args})
+    });
+
+    expect(function () {
+      actual.reply({});
+    }).to.not.throw();
+  });
 });


### PR DESCRIPTION
If the source no longer exists (IE, it was removed from the dom), we shouldn't post message to it.