### PR TITLE
Fixup rollup issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Fix issue where rollup bundlers could not import framebus (see [braintree-web#504](https://github.com/braintree/braintree-web/issues/504))
+
 # v4.0.1
 
 - Fix issue where framebus could not be used with server side rendering

--- a/spec/unit/attach.spec.ts
+++ b/spec/unit/attach.spec.ts
@@ -1,5 +1,5 @@
 import { attach, detach } from "../../src/lib/attach";
-import onmessage from "../../src/lib/message";
+import { onmessage } from "../../src/lib/message";
 
 describe("_attach", function () {
   let addEventSpy: jest.SpyInstance;

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -1,4 +1,4 @@
-import broadcast from "../../src/lib/broadcast";
+import { broadcast } from "../../src/lib/broadcast";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function mkFrame() {

--- a/spec/unit/dispatch.spec.ts
+++ b/spec/unit/dispatch.spec.ts
@@ -1,5 +1,5 @@
 import bus = require("../../src/");
-import dispatch from "../../src/lib/dispatch";
+import { dispatch } from "../../src/lib/dispatch";
 
 describe("dispatch", function () {
   it("should execute subscribers for the given event and origin", function () {

--- a/spec/unit/package-payload.spec.ts
+++ b/spec/unit/package-payload.spec.ts
@@ -1,4 +1,4 @@
-import packagePayload from "../../src/lib/package-payload";
+import { packagePayload } from "../../src/lib/package-payload";
 
 const messagePrefix = "/*framebus*/";
 

--- a/spec/unit/subscribe-replier.spec.ts
+++ b/spec/unit/subscribe-replier.spec.ts
@@ -1,5 +1,5 @@
 import { subscribers } from "../../src/lib/constants";
-import subscribeReplier from "../../src/lib/subscribe-replier";
+import { subscribeReplier } from "../../src/lib/subscribe-replier";
 
 describe("subscribeReplier", function () {
   it("should return UUID of reply event", function () {

--- a/spec/unit/subscription-args-invalid.spec.ts
+++ b/spec/unit/subscription-args-invalid.spec.ts
@@ -1,4 +1,4 @@
-import subscriptionArgsInvalid from "../../src/lib/subscription-args-invalid";
+import { subscriptionArgsInvalid } from "../../src/lib/subscription-args-invalid";
 
 describe("subscriptionArgsInvalid", function () {
   it("should return false for valid types", function () {

--- a/spec/unit/unpack-payload.spec.ts
+++ b/spec/unit/unpack-payload.spec.ts
@@ -1,4 +1,4 @@
-import unpackPayload from "../../src/lib/unpack-payload";
+import { unpackPayload } from "../../src/lib/unpack-payload";
 import type {
   FramebusPayload,
   FramebusSubscriberArg,

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -1,7 +1,7 @@
-import isntString from "./lib/is-not-string";
-import subscriptionArgsInvalid from "./lib/subscription-args-invalid";
-import broadcast from "./lib/broadcast";
-import packagePayload from "./lib/package-payload";
+import { isntString } from "./lib/is-not-string";
+import { subscriptionArgsInvalid } from "./lib/subscription-args-invalid";
+import { broadcast } from "./lib/broadcast";
+import { packagePayload } from "./lib/package-payload";
 
 import type {
   FramebusSubscriberArg,
@@ -12,7 +12,7 @@ import type {
 
 import { childWindows, subscribers } from "./lib/constants";
 
-export default class Framebus {
+export = class Framebus {
   origin: string;
 
   constructor(origin = "*") {
@@ -105,4 +105,4 @@ export default class Framebus {
 
     return false;
   }
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { attach } from "./lib/attach";
-import Framebus from "./framebus";
+import Framebus = require("./framebus");
 
 const bus = new Framebus();
 

--- a/src/lib/attach.ts
+++ b/src/lib/attach.ts
@@ -1,4 +1,4 @@
-import onmessage from "./message";
+import { onmessage } from "./message";
 
 let isAttached = false;
 

--- a/src/lib/broadcast-to-child-windows.ts
+++ b/src/lib/broadcast-to-child-windows.ts
@@ -1,7 +1,7 @@
-import broadcast from "./broadcast";
+import { broadcast } from "./broadcast";
 import { childWindows } from "./constants";
 
-export default function broadcastToChildWindows(
+export function broadcastToChildWindows(
   payload: string,
   origin: string,
   source: Window

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -1,6 +1,6 @@
-import hasOpener from "./has-opener";
+import { hasOpener } from "./has-opener";
 
-export default function broadcast(
+export function broadcast(
   frame: Window,
   payload: string,
   origin: string

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -2,7 +2,7 @@ import { subscribers } from "./constants";
 
 import type { FramebusSubscriberArg, FramebusSubscribeHandler } from "./types";
 
-export default function dispatch(
+export function dispatch(
   origin: string,
   event: string,
   data?: FramebusSubscriberArg,

--- a/src/lib/has-opener.ts
+++ b/src/lib/has-opener.ts
@@ -1,4 +1,4 @@
-export default function hasOpener(frame: Window): boolean {
+export function hasOpener(frame: Window): boolean {
   if (frame.top !== frame) {
     return false;
   }

--- a/src/lib/is-not-string.ts
+++ b/src/lib/is-not-string.ts
@@ -1,3 +1,3 @@
-export default function isntString(str: unknown): boolean {
+export function isntString(str: unknown): boolean {
   return typeof str !== "string";
 }

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,11 +1,11 @@
 import type { FramebusSubscriberArg, FramebusSubscribeHandler } from "./types";
 
-import isntString from "./is-not-string";
-import unpackPayload from "./unpack-payload";
-import dispatch from "./dispatch";
-import broadcastToChildWindows from "./broadcast-to-child-windows";
+import { isntString } from "./is-not-string";
+import { unpackPayload } from "./unpack-payload";
+import { dispatch } from "./dispatch";
+import { broadcastToChildWindows } from "./broadcast-to-child-windows";
 
-export default function onmessage(e: MessageEvent): void {
+export function onmessage(e: MessageEvent): void {
   if (isntString(e.data)) {
     return;
   }

--- a/src/lib/package-payload.ts
+++ b/src/lib/package-payload.ts
@@ -1,4 +1,4 @@
-import subscribeReplier from "./subscribe-replier";
+import { subscribeReplier } from "./subscribe-replier";
 import { prefix } from "./constants";
 
 import type {
@@ -7,7 +7,7 @@ import type {
   FramebusSubscribeHandler,
 } from "./types";
 
-export default function packagePayload(
+export function packagePayload(
   event: string,
   origin: string,
   data?: FramebusSubscriberArg,

--- a/src/lib/subscribe-replier.ts
+++ b/src/lib/subscribe-replier.ts
@@ -1,9 +1,9 @@
-import Framebus from "../framebus";
-import generateUUID from "./uuid";
+import Framebus = require("../framebus");
+import { uuid as generateUUID } from "./uuid";
 
 import type { FramebusSubscriberArg, FramebusSubscribeHandler } from "./types";
 
-export default function subscribeReplier(
+export function subscribeReplier(
   fn: FramebusSubscribeHandler,
   origin: string
 ): string {

--- a/src/lib/subscription-args-invalid.ts
+++ b/src/lib/subscription-args-invalid.ts
@@ -1,8 +1,8 @@
-import isntString from "./is-not-string";
+import { isntString } from "./is-not-string";
 
 import type { FramebusOnHandler } from "./types";
 
-export default function subscriptionArgsInvalid(
+export function subscriptionArgsInvalid(
   event: string,
   fn: FramebusOnHandler,
   origin: string

--- a/src/lib/unpack-payload.ts
+++ b/src/lib/unpack-payload.ts
@@ -1,11 +1,9 @@
 import { prefix } from "./constants";
-import packagePayload from "./package-payload";
+import { packagePayload } from "./package-payload";
 
 import type { FramebusPayload, FramebusSubscriberArg } from "./types";
 
-export default function unpackPayload(
-  e: MessageEvent
-): FramebusPayload | false {
+export function unpackPayload(e: MessageEvent): FramebusPayload | false {
   let payload: FramebusPayload;
 
   if (e.data.slice(0, prefix.length) !== prefix) {

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-mixed-operators */
-export default function uuid(): string {
+export function uuid(): string {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
     const r = (Math.random() * 16) | 0;
     const v = c === "x" ? r : (r & 0x3) | 0x8;


### PR DESCRIPTION
see https://github.com/braintree/braintree-web/issues/504

Looks like using `export default` breaks rollup integrations for some reason 🙃 