### PR TITLE
Use static method for target

### DIFF
--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -19,6 +19,10 @@ export = class Framebus {
     this.origin = origin;
   }
 
+  static target(origin = "*"): Framebus {
+    return new Framebus(origin);
+  }
+
   include(childWindow: Window): boolean {
     if (childWindow == null) {
       return false;
@@ -35,8 +39,8 @@ export = class Framebus {
     return true;
   }
 
-  target(origin = "*"): Framebus {
-    return new Framebus(origin);
+  target(origin: string): Framebus {
+    return Framebus.target(origin);
   }
 
   emit(

--- a/src/lib/subscribe-replier.ts
+++ b/src/lib/subscribe-replier.ts
@@ -14,10 +14,10 @@ export function subscribeReplier(
     replyOriginHandler: FramebusSubscribeHandler
   ): void {
     fn(data, replyOriginHandler);
-    new Framebus().target(origin).off(uuid, replier);
+    Framebus.target(origin).off(uuid, replier);
   }
 
-  new Framebus().target(origin).on(uuid, replier);
+  Framebus.target(origin).on(uuid, replier);
 
   return uuid;
 }


### PR DESCRIPTION
Minor cleanup which should have no impact on users using the sdk, but reduces the number of unnecessary instances of Framebus that get created.