### PR TITLE
Scoped bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+# unreleased
+
+- Allow scoping to a specific channel for events
+
+  ```js
+  var bus = new Framebus({
+    channel: 'some-unique-identifier-used-on-both-the-parent-and-child-pages'
+  });
+  ```
+
+- Add `parentUrl` and `verifyDomain` config to scope messages to specific domains
+  ```js
+  var bus = new Framebus({
+    parentUrl: 'https://parent-url.example.com',
+    verifyDomain: function (url) {
+      // only listens for events emitted from `https://parent-url.example.com` and `https://my-domain.example.com`
+      return url.indexOf('https://my-domain.example.com')
+    }
+  });
+  ```
+- Add `teardown` method for easy cleanup
+
+_Breaking Changes_
+
+- Instantiate new instances of framebus
+
+  ```js
+  // v4
+  var bus = require("framebus");
+  bus.on(/* args */);
+  bus.emit(/* args */);
+
+  // v5
+  var Framebus = require("framebus");
+  var bus = new Framebus();
+  bus.on(/* args */);
+  bus.emit(/* args */);
+  ```
+
+- Instantiating a framebus with `target` method with an `origin` param now requires an options object (same object that is used to instantiate the instance)
+
+  ```js
+  // v4
+  var bus = require("framebus");
+  var anotherBus = bus.target("example.com");
+
+  // v5
+  var Framebus = require("framebus");
+  var bus = Framebus.target({
+    origin: "example.com"
+  });
+  var anotherBus = bus.target({
+    origin: "example.com"
+  });
+  ```
+
 # 4.0.5
 
 - Fixup Framebus typing for Typescript integrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@
   });
   ```
 
-- Add `parentUrl` and `verifyDomain` config to scope messages to specific domains
+- Add `verifyDomain` config to scope messages to specific domains
   ```js
   var bus = new Framebus({
-    parentUrl: "https://parent-url.example.com",
     verifyDomain: function (url) {
       // only listens for events emitted from `https://parent-url.example.com` and `https://my-domain.example.com`
       return url.indexOf("https://my-domain.example.com");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 
   ```js
   var bus = new Framebus({
-    channel: 'some-unique-identifier-used-on-both-the-parent-and-child-pages'
+    channel: "some-unique-identifier-used-on-both-the-parent-and-child-pages",
   });
   ```
 
 - Add `parentUrl` and `verifyDomain` config to scope messages to specific domains
   ```js
   var bus = new Framebus({
-    parentUrl: 'https://parent-url.example.com',
+    parentUrl: "https://parent-url.example.com",
     verifyDomain: function (url) {
       // only listens for events emitted from `https://parent-url.example.com` and `https://my-domain.example.com`
-      return url.indexOf('https://my-domain.example.com')
-    }
+      return url.indexOf("https://my-domain.example.com");
+    },
   });
   ```
 - Add `teardown` method for easy cleanup
@@ -47,10 +47,10 @@ _Breaking Changes_
   // v5
   var Framebus = require("framebus");
   var bus = Framebus.target({
-    origin: "example.com"
+    origin: "example.com",
   });
   var anotherBus = bus.target({
-    origin: "example.com"
+    origin: "example.com",
   });
   ```
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The Framebus class takes a configuration object, where all the params are option
 
 ```js
 type FramebusOptions = {
-  origin?: string; // default: "*"
-  channel?: string; // no default
-  parentUrl?: string; // no default
-  verifyDomain?: (url: string) => boolean; // no default
-}
+  origin?: string, // default: "*"
+  channel?: string, // no default
+  parentUrl?: string, // no default
+  verifyDomain?: (url: string) => boolean, // no default
+};
 ```
 
 The `origin` sets the framebus instance to only operate on the chosen origin.
@@ -48,7 +48,7 @@ var bus = new Framebus({
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
     url.indexOf("https://my-domain") === 0;
-  }
+  },
 });
 ```
 
@@ -61,14 +61,16 @@ var bus = new Framebus({
 This method is used in conjuction with `emit`, `on`, and `off` to restrict their results to the given origin. By default, an origin of `'*'` is used.
 
 ```javascript
-framebus.target({
-  origin: "https://example.com"
-}).on("my cool event", function () {});
+framebus
+  .target({
+    origin: "https://example.com",
+  })
+  .on("my cool event", function () {});
 // will ignore all incoming 'my cool event' NOT from 'https://example.com'
 ```
 
 | Argument  | Type            | Description                        |
-|-----------|-----------------|------------------------------------|
+| --------- | --------------- | ---------------------------------- |
 | `options` | FramebusOptions | See above section for more details |
 
 #### `emit('event', data? , callback?): boolean`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Framebus allows you to easily send messages across frames (and iframes) with a s
 In one frame:
 
 ```js
-var bus = require("framebus");
+var Framebus = require("framebus");
+var bus = new Framebus();
 
 bus.emit("message", {
   from: "Ron",
@@ -16,29 +17,59 @@ bus.emit("message", {
 In another frame:
 
 ```js
-var bus = require("framebus");
+var Framebus = require("framebus");
+var bus = new Framebus();
 
 bus.on("message", function (data) {
   console.log(data.from + " said: " + data.contents);
 });
 ```
 
+The Framebus class takes a configuration object, where all the params are optional.
+
+```js
+type FramebusOptions = {
+  origin?: string; // default: "*"
+  channel?: string; // no default
+  parentUrl?: string; // no default
+  verifyDomain?: (url: string) => boolean; // no default
+}
+```
+
+The `origin` sets the framebus instance to only operate on the chosen origin.
+
+The `channel` namespaces the events called with `on` and `emit` so you can have multiple bus instances on the page and have them only communicate with busses with the same channel value.
+
+The `parentUrl` and `verifyDomain` are used in conjunction. If a `parentUrl` is passed, then the `on` listener will only fire if the domain of the origin of the post message matches the `parentUrl`'s domain or the function passed for `verifyDomain` returns `true`.
+
+```js
+var bus = new Framebus({
+  parentUrl: "https://example.com/sub-page",
+  verifyDomain: function (url) {
+    // only return true if the domain of the url matches exactly
+    url.indexOf("https://my-domain") === 0;
+  }
+});
+```
+
 ## API
 
-#### `target(origin): framebus`
+#### `target(options: FramebusOptions): framebus`
 
 **returns**: a chainable instance of framebus that operates on the chosen origin.
 
 This method is used in conjuction with `emit`, `on`, and `off` to restrict their results to the given origin. By default, an origin of `'*'` is used.
 
 ```javascript
-framebus.target("https://example.com").on("my cool event", function () {});
+framebus.target({
+  origin: "https://example.com"
+}).on("my cool event", function () {});
 // will ignore all incoming 'my cool event' NOT from 'https://example.com'
 ```
 
-| Argument | Type   | Description                                          |
-| -------- | ------ | ---------------------------------------------------- |
-| `origin` | String | (default: `'*'`) only target frames with this origin |
+| Argument  | Type            | Description                        |
+|-----------|-----------------|------------------------------------|
+| `options` | FramebusOptions | See above section for more details |
 
 #### `emit('event', data? , callback?): boolean`
 
@@ -86,6 +117,22 @@ framebus.emit("hello popup and friends!");
 | Argument | Type   | Description                                  |
 | -------- | ------ | -------------------------------------------- |
 | `popup`  | Window | The popup refrence returned by `window.open` |
+
+#### `teardown(): void`
+
+Calls `off` on all listeners used for this bus instance and makes subsequent calls to all methods `noop`.
+
+```javascript
+bus.on("event-name", handler);
+
+// event-name listener is torn down
+bus.teardown();
+
+// these now do nothing
+bus.on("event-name", handler);
+bus.emit("event-name", data);
+bus.off("event-name", handler);
+```
 
 ## Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The Framebus class takes a configuration object, where all the params are option
 type FramebusOptions = {
   origin?: string, // default: "*"
   channel?: string, // no default
-  parentUrl?: string, // no default
   verifyDomain?: (url: string) => boolean, // no default
 };
 ```
@@ -40,11 +39,10 @@ The `origin` sets the framebus instance to only operate on the chosen origin.
 
 The `channel` namespaces the events called with `on` and `emit` so you can have multiple bus instances on the page and have them only communicate with busses with the same channel value.
 
-The `parentUrl` and `verifyDomain` are used in conjunction. If a `parentUrl` is passed, then the `on` listener will only fire if the domain of the origin of the post message matches the `parentUrl`'s domain or the function passed for `verifyDomain` returns `true`.
+If a `verifyDomain` is passed, then the `on` listener will only fire if the domain of the origin of the post message matches the `location.href` value of page or the function passed for `verifyDomain` returns `true`.
 
 ```js
 var bus = new Framebus({
-  parentUrl: "https://example.com/sub-page",
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
     url.indexOf("https://my-domain") === 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ function cleanTest() {
 function build() {
   const b = browserify({
     entries: "./src/index.ts",
-    standalone: "framebus",
+    standalone: "Framebus",
     debug: true,
   });
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "restoreMocks": true,
+    "resetMocks": true,
     "setupFilesAfterEnv": [
       "./spec/unit/helpers.ts"
     ]

--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
   "jest": {
     "preset": "ts-jest",
     "restoreMocks": true,
-    "resetMocks": true,
-    "setupFilesAfterEnv": [
-      "./spec/unit/helpers.ts"
-    ]
+    "resetMocks": true
   }
 }

--- a/spec/functional/popup-spec.js
+++ b/spec/functional/popup-spec.js
@@ -1,15 +1,15 @@
-describe("Popup Events", function () {
-  beforeEach(function () {
+describe("Popup Events", () => {
+  beforeEach(() => {
     browser.url("http://localhost:3099");
   });
 
-  it("should be able to receive events from opener frames", function () {
+  it("should be able to receive events from opener frames", () => {
     const expected = "hello from frame3!";
 
     $("#open-popup").click();
     browser.switchWindow("popup");
     browser.waitUntil(
-      function () {
+      () => {
         return $("body").getHTML() != null;
       },
       {
@@ -28,7 +28,7 @@ describe("Popup Events", function () {
     browser.switchWindow("popup");
 
     browser.waitUntil(
-      function () {
+      () => {
         return $("p").getHTML !== "";
       },
       {
@@ -40,14 +40,14 @@ describe("Popup Events", function () {
     expect(actual).toBe(expected);
   });
 
-  it("should be able to send events to opener frames", function () {
+  it("should be able to send events to opener frames", () => {
     const expected = "hello from popup!";
 
     $("#open-popup").click();
 
     browser.switchWindow("popup");
     browser.waitUntil(
-      function () {
+      () => {
         return $("body").getHTML() != null;
       },
       {
@@ -63,7 +63,7 @@ describe("Popup Events", function () {
     browser.switchToFrame(1);
 
     browser.waitUntil(
-      function () {
+      () => {
         return $("p").getHTML !== "";
       },
       {
@@ -75,14 +75,14 @@ describe("Popup Events", function () {
     expect(actual).toContain(expected);
   });
 
-  it("should not double-receive events in popups", function () {
+  it("should not double-receive events in popups", () => {
     const expected = "hello from popup!";
 
     $("#open-popup").click();
 
     browser.switchWindow("popup");
     browser.waitUntil(
-      function () {
+      () => {
         return $("body").getHTML() != null;
       },
       {
@@ -98,7 +98,7 @@ describe("Popup Events", function () {
     browser.switchToFrame(1);
 
     browser.waitUntil(
-      function () {
+      () => {
         return $("p").getHTML !== "";
       },
       {

--- a/spec/functional/public/html/frame1-inner.html
+++ b/spec/functional/public/html/frame1-inner.html
@@ -13,7 +13,9 @@
       var button = document.getElementById("marco-button");
 
       button.onclick = function () {
-        framebus.target(remoteOrigin).emit(
+        Framebus.target({
+          origin: remoteOrigin
+        }).emit(
           "Marco",
           {
             message: "are you there?",

--- a/spec/functional/public/html/frame1-inner.html
+++ b/spec/functional/public/html/frame1-inner.html
@@ -14,7 +14,7 @@
 
       button.onclick = function () {
         Framebus.target({
-          origin: remoteOrigin
+          origin: remoteOrigin,
         }).emit(
           "Marco",
           {

--- a/spec/functional/public/html/frame1.html
+++ b/spec/functional/public/html/frame1.html
@@ -8,7 +8,8 @@
     frame1.html
     <script src="/js/test-app.js"></script>
     <script>
-      framebus.on("Marco", function () {
+      var bus = new Framebus();
+      bus.on("Marco", function () {
         app.printToDOM('FAIL: [frame 1] received "Marco"');
       });
     </script>

--- a/spec/functional/public/html/frame2.html
+++ b/spec/functional/public/html/frame2.html
@@ -13,10 +13,11 @@
     >
     <script src="/js/test-app.js"></script>
     <script>
-      framebus.on("Marco", function () {
+      var bus = new Framebus();
+      bus.on("Marco", function () {
         app.printToDOM('FAIL: [frame 2] received "Marco"');
       });
-      framebus.on("from-popup", function (data) {
+      bus.on("from-popup", function (data) {
         app.printToDOM('received "' + data.message + '" from popup');
       });
     </script>

--- a/spec/functional/public/html/frame3.html
+++ b/spec/functional/public/html/frame3.html
@@ -13,13 +13,15 @@
 
     <script src="/js/test-app.js"></script>
     <script>
+      var bus = new Framebus();
+
       document.querySelector("#send").addEventListener("click", function () {
-        framebus.emit("message", {
+        bus.emit("message", {
           message: document.querySelector("#popup-message").value,
         });
       });
 
-      framebus.on("Marco", function (data, reply) {
+      bus.on("Marco", function (data, reply) {
         var polo = document.getElementById("polo-text").value;
         app.printToDOM(data.message);
         reply({

--- a/spec/functional/public/html/popup.html
+++ b/spec/functional/public/html/popup.html
@@ -10,14 +10,16 @@
     <button id="send">Send</button>
     <script src="/js/test-app.js"></script>
     <script>
-      framebus.on("message", function (data) {
+      var bus = new Framebus();
+
+      bus.on("message", function (data) {
         app.printToDOM(data.message);
       });
 
       document.querySelector("#send").addEventListener(
         "click",
         function () {
-          framebus.emit("from-popup", {
+          bus.emit("from-popup", {
             message: document.querySelector("#from-popup-message").value,
           });
         },
@@ -25,7 +27,7 @@
       );
 
       var count = 0;
-      framebus.on("from-popup", function () {
+      bus.on("from-popup", function () {
         count++;
 
         if (count > 1) {

--- a/spec/functional/public/index.html
+++ b/spec/functional/public/index.html
@@ -19,7 +19,9 @@
     </script>
     <script src="/js/test-app.js"></script>
     <script>
-      framebus.on("Marco", function () {
+      var bus = new Framebus();
+
+      bus.on("Marco", function () {
         app.printToDOM('FAIL: [index] received "Marco"');
       });
 
@@ -27,7 +29,7 @@
         "click",
         function () {
           var popup = window.open("/html/popup.html", "popup");
-          framebus.include(popup);
+          bus.include(popup);
         },
         false
       );

--- a/spec/functional/reply-spec.js
+++ b/spec/functional/reply-spec.js
@@ -1,9 +1,9 @@
-describe("Reply Events", function () {
-  beforeEach(function () {
+describe("Reply Events", () => {
+  beforeEach(() => {
     browser.url("http://localhost:3099");
   });
 
-  it("should only publish to targeted domains and print reply", function () {
+  it("should only publish to targeted domains and print reply", () => {
     browser.switchToFrame(2);
 
     $("#polo-text").setValue("polo");
@@ -16,7 +16,7 @@ describe("Reply Events", function () {
     $("#marco-button").click();
 
     browser.waitUntil(
-      function () {
+      () => {
         return $("p").getText() === "polo";
       },
       {

--- a/spec/functional/server.js
+++ b/spec/functional/server.js
@@ -48,7 +48,7 @@ function start(cb, logRequests) {
 
   const asyncTasks = ports.map(function (port) {
     return function (done) {
-      const srv = app.listen(port, function () {
+      const srv = app.listen(port, () => {
         console.log("app running on", port);
         done(null, srv);
       });
@@ -67,29 +67,29 @@ function stop(cb) {
   async.parallel(
     servers.map(function (server) {
       return function (done) {
-        server.close(function () {
+        server.close(() => {
           console.log("server killed");
           done();
         });
       };
     }),
-    function () {
+    () => {
       cb();
     }
   );
 }
 
 module.exports = {
-  start: function () {
+  start() {
     return new Promise(function (done) {
-      start(function () {
+      start(() => {
         done();
       });
     });
   },
-  stop: function () {
+  stop() {
     return new Promise(function (done) {
-      stop(function () {
+      stop(() => {
         done();
       });
     });

--- a/spec/unit/attach.spec.ts
+++ b/spec/unit/attach.spec.ts
@@ -1,21 +1,21 @@
 import { attach, detach } from "../../src/lib/attach";
 import { onmessage } from "../../src/lib/message";
 
-describe("_attach", function () {
+describe("_attach", () => {
   let addEventSpy: jest.SpyInstance;
 
-  beforeEach(function () {
+  beforeEach(() => {
     detach();
     addEventSpy = jest.spyOn(window, "addEventListener").mockImplementation();
   });
 
-  it("should add listener to scope", function () {
+  it("should add listener to scope", () => {
     attach();
 
     expect(addEventSpy).toBeCalledWith("message", onmessage, false);
   });
 
-  it("should only add listener to scope once", function () {
+  it("should only add listener to scope once", () => {
     attach();
     attach();
 

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -9,19 +9,19 @@ function mkFrame() {
   };
 }
 
-describe("broadcast", function () {
-  it("should not throw exception when postMessage is denied", function () {
+describe("broadcast", () => {
+  it("should not throw exception when postMessage is denied", () => {
     const frame = mkFrame();
     frame.postMessage.mockImplementation(() => {
       throw new Error("Invalid calling object");
     });
 
-    expect(function () {
+    expect(() => {
       broadcast(frame, "payload", "*");
     }).not.toThrowError();
   });
 
-  it("should postMessage to current frame", function () {
+  it("should postMessage to current frame", () => {
     const frame = mkFrame();
 
     broadcast(frame, "payload", "*");
@@ -29,7 +29,7 @@ describe("broadcast", function () {
     expect(frame.postMessage).toBeCalled();
   });
 
-  it("should postMessage to current frame's child frames", function () {
+  it("should postMessage to current frame's child frames", () => {
     const frame = mkFrame();
     frame.frames[0] = mkFrame();
 
@@ -38,8 +38,8 @@ describe("broadcast", function () {
     expect(frame.frames[0].postMessage).toBeCalled();
   });
 
-  describe("to opener", function () {
-    it("should postMessage to window.top.opener if it exists", function () {
+  describe("to opener", () => {
+    it("should postMessage to window.top.opener if it exists", () => {
       const frame = mkFrame();
 
       frame.opener = mkFrame();
@@ -51,7 +51,7 @@ describe("broadcast", function () {
       expect(frame.opener.top.postMessage).toBeCalled();
     });
 
-    it("should not postMessage to window.opener if it has closed", function () {
+    it("should not postMessage to window.opener if it has closed", () => {
       const frame = mkFrame();
 
       frame.opener = {
@@ -97,7 +97,7 @@ describe("broadcast", function () {
       done();
     });
 
-    it("should postMessage to the window.opener's child frames", function () {
+    it("should postMessage to the window.opener's child frames", () => {
       const frame = mkFrame();
       const openerFrame = mkFrame();
 
@@ -112,18 +112,18 @@ describe("broadcast", function () {
       expect(frame.opener.top.frames[0].postMessage).toBeCalled();
     });
 
-    it("should not throw if window.opener has access denied", function () {
+    it("should not throw if window.opener has access denied", () => {
       const frame = mkFrame();
 
       frame.top = frame;
 
       Object.defineProperty(frame, "opener", {
-        get: function () {
+        get() {
           throw new Error("Access denied");
         },
       });
 
-      expect(function () {
+      expect(() => {
         broadcast(frame, "payload", "*");
       }).not.toThrowError("Access denied");
     });

--- a/spec/unit/dispatch.spec.ts
+++ b/spec/unit/dispatch.spec.ts
@@ -1,8 +1,8 @@
 import bus = require("../../src/");
 import { dispatch } from "../../src/lib/dispatch";
 
-describe("dispatch", function () {
-  it("should execute subscribers for the given event and origin", function () {
+describe("dispatch", () => {
+  it("should execute subscribers for the given event and origin", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
@@ -14,7 +14,7 @@ describe("dispatch", function () {
     expect(subscriber).toBeCalledWith({ data: "data" });
   });
 
-  it("should not execute subscribers for a different event", function () {
+  it("should not execute subscribers for a different event", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
@@ -25,7 +25,7 @@ describe("dispatch", function () {
     expect(subscriber).not.toBeCalled();
   });
 
-  it("should not execute subscribers for a different domain", function () {
+  it("should not execute subscribers for a different domain", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
@@ -36,7 +36,7 @@ describe("dispatch", function () {
     expect(subscriber).not.toBeCalled();
   });
 
-  it("can pass a reply handler", function () {
+  it("can pass a reply handler", () => {
     const subscriber = jest.fn();
     const reply = jest.fn();
     const origin = "https://example.com";
@@ -49,7 +49,7 @@ describe("dispatch", function () {
     expect(subscriber).toBeCalledWith({ data: "data" }, reply);
   });
 
-  it("can pass a reply handler wthout data", function () {
+  it("can pass a reply handler wthout data", () => {
     const subscriber = jest.fn();
     const reply = jest.fn();
     const origin = "https://example.com";

--- a/spec/unit/dispatch.spec.ts
+++ b/spec/unit/dispatch.spec.ts
@@ -1,4 +1,4 @@
-import bus = require("../../src/");
+import Framebus = require("../../src/");
 import { dispatch } from "../../src/lib/dispatch";
 
 describe("dispatch", () => {
@@ -6,7 +6,9 @@ describe("dispatch", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
-    bus.target(origin).on("test event", subscriber);
+    Framebus.target({
+      origin,
+    }).on("test event", subscriber);
 
     dispatch(origin, "test event", { data: "data" });
 
@@ -18,7 +20,9 @@ describe("dispatch", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
-    bus.target(origin).on("test event", subscriber);
+    Framebus.target({
+      origin,
+    }).on("test event", subscriber);
 
     dispatch(origin, "different event", { data: "data" });
 
@@ -29,7 +33,9 @@ describe("dispatch", () => {
     const subscriber = jest.fn();
     const origin = "https://example.com";
 
-    bus.target(origin).on("test event", subscriber);
+    Framebus.target({
+      origin,
+    }).on("test event", subscriber);
 
     dispatch("https://domain.com", "test event", { data: "data" });
 
@@ -41,7 +47,9 @@ describe("dispatch", () => {
     const reply = jest.fn();
     const origin = "https://example.com";
 
-    bus.target(origin).on("test event", subscriber);
+    Framebus.target({
+      origin,
+    }).on("test event", subscriber);
 
     dispatch(origin, "test event", { data: "data" }, reply);
 
@@ -54,7 +62,9 @@ describe("dispatch", () => {
     const reply = jest.fn();
     const origin = "https://example.com";
 
-    bus.target(origin).on("test event", subscriber);
+    Framebus.target({
+      origin,
+    }).on("test event", subscriber);
 
     // eslint-disable-next-line no-undefined
     dispatch(origin, "test event", undefined, reply);

--- a/spec/unit/emit.spec.ts
+++ b/spec/unit/emit.spec.ts
@@ -1,9 +1,10 @@
-import { attach } from "../../src/lib/attach";
-import bus = require("../../src/");
+import Framebus = require("../../src/");
 
 describe("emit", () => {
+  let bus: Framebus;
+
   beforeEach(() => {
-    attach();
+    bus = new Framebus();
   });
 
   it("should return false if event is not a string", () => {
@@ -15,8 +16,12 @@ describe("emit", () => {
 
   it("should return false if origin is not a string", () => {
     const actual = bus
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .target({ origin: "object" } as any)
+      .target({
+        origin: {
+          foo: "object",
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
       .emit("event", { data: "data" });
 
     expect(actual).toBe(false);
@@ -24,14 +29,20 @@ describe("emit", () => {
 
   it("should return true if origin and event are strings", () => {
     const actual = bus
-      .target("https://example.com")
+      .target({
+        origin: "https://example.com",
+      })
       .emit("event", { data: "data" });
 
     expect(actual).toBe(true);
   });
 
   it("can pass a reply function without passing data", () => {
-    const actual = bus.target("https://example.com").emit("event", jest.fn());
+    const actual = bus
+      .target({
+        origin: "https://example.com",
+      })
+      .emit("event", jest.fn());
 
     expect(actual).toBe(true);
   });

--- a/spec/unit/emit.spec.ts
+++ b/spec/unit/emit.spec.ts
@@ -1,19 +1,19 @@
 import { attach } from "../../src/lib/attach";
 import bus = require("../../src/");
 
-describe("emit", function () {
-  beforeEach(function () {
+describe("emit", () => {
+  beforeEach(() => {
     attach();
   });
 
-  it("should return false if event is not a string", function () {
+  it("should return false if event is not a string", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actual = bus.emit({} as any, { data: "data" });
 
     expect(actual).toBe(false);
   });
 
-  it("should return false if origin is not a string", function () {
+  it("should return false if origin is not a string", () => {
     const actual = bus
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .target({ origin: "object" } as any)
@@ -22,7 +22,7 @@ describe("emit", function () {
     expect(actual).toBe(false);
   });
 
-  it("should return true if origin and event are strings", function () {
+  it("should return true if origin and event are strings", () => {
     const actual = bus
       .target("https://example.com")
       .emit("event", { data: "data" });
@@ -30,7 +30,7 @@ describe("emit", function () {
     expect(actual).toBe(true);
   });
 
-  it("can pass a reply function without passing data", function () {
+  it("can pass a reply function without passing data", () => {
     const actual = bus.target("https://example.com").emit("event", jest.fn());
 
     expect(actual).toBe(true);

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -1,0 +1,615 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+jest.mock("../../src/lib/broadcast");
+
+import { attach } from "../../src/lib/attach";
+import { broadcast } from "../../src/lib/broadcast";
+import { Framebus } from "../../src/framebus";
+import { subscribers } from "../../src/lib/constants";
+
+describe("Framebus", () => {
+  let bus: Framebus;
+
+  beforeEach(() => {
+    bus = new Framebus();
+    attach();
+  });
+
+  afterEach(() => {
+    Object.keys(subscribers).forEach((subKey) => {
+      delete subscribers[subKey];
+    });
+  });
+
+  describe("target", () => {
+    it("returns a new Framebus isntance", () => {
+      const instance = Framebus.target();
+
+      expect(instance).toBeInstanceOf(Framebus);
+    });
+
+    it("can pass setup options", () => {
+      const instance = Framebus.target({
+        channel: "unique-channel",
+        origin: "unique-origin",
+        parentUrl: "https://example.com",
+      });
+
+      expect(instance.channel).toBe("unique-channel");
+      expect(instance.origin).toBe("unique-origin");
+      expect(instance.parentUrl).toBe("https://example.com");
+    });
+
+    it("uses static version when called on instance", () => {
+      const instance = new Framebus();
+
+      jest.spyOn(Framebus, "target").mockImplementation();
+
+      instance.target({
+        channel: "unique-channel",
+        origin: "unique-origin",
+        parentUrl: "https://example.com",
+      });
+
+      expect(Framebus.target).toBeCalledTimes(1);
+      expect(Framebus.target).toBeCalledWith({
+        channel: "unique-channel",
+        origin: "unique-origin",
+        parentUrl: "https://example.com",
+      });
+    });
+  });
+
+  describe("include", () => {
+    it("returns false if no widow is passed", () => {
+      // @ts-ignore
+      expect(bus.include()).toBe(false);
+    });
+
+    it("returns false if window has no Window propeerty", () => {
+      // @ts-ignore
+      expect(bus.include({})).toBe(false);
+    });
+
+    it("returns false if window's constructor does not equal the Window property", () => {
+      expect(
+        bus.include({
+          // @ts-ignore
+          Window: "fake window",
+        })
+      ).toBe(false);
+    });
+
+    it("returns true if window is included", () => {
+      const fakeWindow = {};
+
+      expect(
+        bus.include({
+          // @ts-ignore
+          Window: fakeWindow,
+          // @ts-ignore
+          constructor: fakeWindow,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("emit", () => {
+    it("returns true when subscriber is added", () => {
+      expect(bus.emit("event-name")).toBe(true);
+      expect(bus.emit("event-name", { foo: "bar" })).toBe(true);
+      expect(bus.emit("event-name", { foo: "bar" }, jest.fn())).toBe(true);
+      expect(bus.emit("event-name", jest.fn())).toBe(true);
+    });
+
+    it("returns false when subscriber is not added", () => {
+      // @ts-ignore
+      expect(bus.emit({ notAString: 12 })).toBe(false);
+    });
+
+    it("broadcasts", () => {
+      const data = { foo: "bar" };
+      bus.emit("event-name", data, () => {
+        // noop
+      });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"foo":"bar"'),
+        "*"
+      );
+    });
+
+    it("does not broadcast if torn down", () => {
+      bus.teardown();
+
+      expect(bus.emit("event-name")).toBe(false);
+      expect(broadcast).toBeCalledTimes(0);
+    });
+
+    it("broadcasts to specified origin", () => {
+      bus = new Framebus({
+        origin: "foo",
+      });
+
+      const data = { foo: "bar" };
+      bus.emit("event-name", data, () => {
+        // noop
+      });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"foo":"bar"'),
+        "foo"
+      );
+    });
+
+    it("broadcasts to specified channel", () => {
+      bus = new Framebus({
+        channel: "unique-channel",
+      });
+
+      const data = { foo: "bar" };
+      bus.emit("event-name", data, () => {
+        // noop
+      });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"unique-channel:event-name"'),
+        "*"
+      );
+    });
+
+    it("does not require data", () => {
+      bus.emit("event-name", () => {
+        // noop
+      });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"event-name"'),
+        "*"
+      );
+    });
+
+    it("does not require a callback", () => {
+      bus.emit("event-name", { foo: "bar" });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"foo":"bar"'),
+        "*"
+      );
+    });
+
+    it("does not require data or a callback", () => {
+      bus.emit("event-name");
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(
+        window.top,
+        expect.stringContaining('"event-name"'),
+        "*"
+      );
+    });
+  });
+
+  describe("on", () => {
+    it("returns true when listener is added", () => {
+      expect(bus.on("event-name", jest.fn())).toBe(true);
+    });
+
+    it("returns false when listener is not added", () => {
+      // @ts-ignore
+      expect(bus.on("on-without-a-handler")).toBe(false);
+    });
+
+    it("listens for event", () => {
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"][0]).toBe(handler);
+    });
+
+    it("can listen multiple times for event", () => {
+      const handler = jest.fn();
+      const handler2 = jest.fn();
+      const handler3 = jest.fn();
+      bus.on("event-name", handler);
+      bus.on("event-name", handler2);
+      bus.on("event-name", handler3);
+
+      expect(subscribers["*"]["event-name"][0]).toBe(handler);
+      expect(subscribers["*"]["event-name"][1]).toBe(handler2);
+      expect(subscribers["*"]["event-name"][2]).toBe(handler3);
+    });
+
+    it("does not subscribe handler when bus is torn down", () => {
+      bus.teardown();
+
+      expect(bus.on("event-name", jest.fn())).toBe(false);
+
+      expect(subscribers).toEqual({});
+    });
+
+    it("can scope to origin", () => {
+      bus = new Framebus({
+        origin: "foo",
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(subscribers["foo"]["event-name"][0]).toBe(handler);
+    });
+
+    it("can scope to channel", () => {
+      bus = new Framebus({
+        channel: "unique-channel",
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(subscribers["*"]["unique-channel:event-name"][0]).toBe(handler);
+    });
+
+    it("modifies handler if parent url is used", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com",
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler(
+        {
+          data: "foo",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith({ data: "foo" }, cb);
+    });
+
+    it("does not call original handler when a verification domain method is passed and the check fails", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler(
+        {
+          data: "foo",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(0);
+    });
+
+    it("does call original handler when a verification domain method is passed and the check passes", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com",
+        verifyDomain(url) {
+          return url === "https://not-example.com/allowed";
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "https://not-example.com/dissallowed",
+        },
+        {
+          data: "disallowed",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(0);
+
+      newHandler.call(
+        {
+          origin: "https://not-example.com/allowed",
+        },
+        {
+          data: "allowed",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith({ data: "allowed" }, cb);
+    });
+
+    it("does call original handler when a verification domain method fails, but post message origin matches parentUrl", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "https://example.com",
+        },
+        {
+          data: "allowed",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith({ data: "allowed" }, cb);
+    });
+
+    it("does call original handler when a verification domain method fails, but post message origin matches parentUrl (ignoringg ssl port)", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com:443",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "https://example.com",
+        },
+        {
+          data: "allowed",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith({ data: "allowed" }, cb);
+    });
+
+    it("does call original handler when a verification domain method fails, but post message origin matches parentUrl (ignoringg http port)", () => {
+      bus = new Framebus({
+        parentUrl: "http://example.com:80",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "http://example.com",
+        },
+        {
+          data: "allowed",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith({ data: "allowed" }, cb);
+    });
+
+    it("does not call original handler when a verification domain method fails and parent url matches but non-standard port is used", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com:123",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "https://example.com",
+        },
+        {
+          data: "foo",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(0);
+    });
+
+    it("does not call original handler when a verification domain method fails and parent url matches but protocol does not", () => {
+      bus = new Framebus({
+        parentUrl: "https://example.com",
+        verifyDomain() {
+          return false;
+        },
+      });
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      const newHandler = subscribers["*"]["event-name"][0];
+
+      expect(newHandler).toBeInstanceOf(Function);
+      expect(newHandler).not.toBe(handler);
+
+      const cb = jest.fn();
+      newHandler.call(
+        {
+          origin: "http://example.com",
+        },
+        {
+          data: "foo",
+        },
+        cb
+      );
+
+      expect(handler).toBeCalledTimes(0);
+    });
+  });
+
+  describe("off", () => {
+    it("returns true when subscriber is removed", () => {
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(bus.off("event-name", handler)).toBe(true);
+    });
+
+    it("returns false when subscriber is not removed", () => {
+      bus.on("event-name", jest.fn());
+
+      // @ts-ignore
+      expect(bus.off("event-without-handler")).toBe(false);
+      expect(bus.off("event-without-first-calling-on", jest.fn())).toBe(false);
+
+      bus.on("new-event", jest.fn());
+
+      // with a new handler
+      expect(bus.off("new-event", jest.fn())).toBe(false);
+    });
+
+    it("removes subscriber", () => {
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+
+      bus.off("event-name", handler);
+      expect(subscribers["*"]["event-name"].length).toBe(0);
+    });
+
+    it("does nothing when bus is torn down", () => {
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+
+      bus.teardown();
+
+      expect(bus.off("event-name", handler)).toBe(false);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+    });
+
+    it("can scope by origin", () => {
+      const busWithOrigin = new Framebus({
+        origin: "foo",
+      });
+
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+      busWithOrigin.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+      expect(subscribers["foo"]["event-name"].length).toBe(1);
+
+      busWithOrigin.off("event-name", handler);
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+      expect(subscribers["foo"]["event-name"].length).toBe(0);
+    });
+
+    it("can scope by channel", () => {
+      const busWithChannel = new Framebus({
+        channel: "unique-id",
+      });
+
+      const handler = jest.fn();
+      bus.on("event-name", handler);
+      busWithChannel.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+      expect(subscribers["*"]["unique-id:event-name"].length).toBe(1);
+
+      busWithChannel.off("event-name", handler);
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+      expect(subscribers["*"]["unique-id:event-name"].length).toBe(0);
+    });
+
+    it("handles parentUrl", () => {
+      const busWithParentUrl = new Framebus({
+        parentUrl: "https://example.com",
+      });
+
+      const handler = jest.fn();
+      busWithParentUrl.on("event-name", handler);
+
+      expect(subscribers["*"]["event-name"].length).toBe(1);
+
+      busWithParentUrl.off("event-name", handler);
+      expect(subscribers["*"]["event-name"].length).toBe(0);
+    });
+  });
+
+  describe("teardown", () => {
+    it("calls off on all listeners", () => {
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const handler3 = jest.fn();
+
+      jest.spyOn(bus, "off");
+
+      bus.on("event-1", handler1);
+      bus.on("event-2", handler2);
+      bus.on("event-3", handler3);
+
+      bus.teardown();
+
+      expect(bus.off).toBeCalledTimes(3);
+      expect(bus.off).toBeCalledWith("event-1", handler1);
+      expect(bus.off).toBeCalledWith("event-2", handler2);
+      expect(bus.off).toBeCalledWith("event-3", handler3);
+    });
+  });
+});

--- a/spec/unit/helpers.ts
+++ b/spec/unit/helpers.ts
@@ -1,6 +1,0 @@
-import { detach } from "../../src/lib/attach";
-
-afterEach(() => {
-  jest.restoreAllMocks();
-  detach();
-});

--- a/spec/unit/helpers.ts
+++ b/spec/unit/helpers.ts
@@ -1,6 +1,6 @@
 import { detach } from "../../src/lib/attach";
 
-afterEach(function () {
+afterEach(() => {
   jest.restoreAllMocks();
   detach();
 });

--- a/spec/unit/off.spec.ts
+++ b/spec/unit/off.spec.ts
@@ -1,8 +1,8 @@
 import { subscribers } from "../../src/lib/constants";
 import bus = require("../../src/");
 
-describe("off", function () {
-  it("should remove subscriber given event and origin", function () {
+describe("off", () => {
+  it("should remove subscriber given event and origin", () => {
     const event = "the event";
     const origin = "https://example.com";
     const fn = jest.fn();
@@ -16,7 +16,7 @@ describe("off", function () {
     expect(subscribers[origin][event].length).toBe(1);
   });
 
-  it("should correctly update the array", function () {
+  it("should correctly update the array", () => {
     const event = "the event";
     const origin = "https://example.com";
     const fn = jest.fn();
@@ -29,7 +29,7 @@ describe("off", function () {
     expect(subscribers[origin][event].length).toBe(1);
   });
 
-  it("should return true if removed", function () {
+  it("should return true if removed", () => {
     const event = "the event";
     const origin = "https://example.com";
     const fn = jest.fn();
@@ -42,7 +42,7 @@ describe("off", function () {
     expect(actual).toBe(true);
   });
 
-  it("should return false if not removed for unknown event", function () {
+  it("should return false if not removed for unknown event", () => {
     const event = "the event";
     const origin = "https://example.com";
     const fn = jest.fn();
@@ -55,7 +55,7 @@ describe("off", function () {
     expect(actual).toBe(false);
   });
 
-  it("should return false if not removed for unknown origin", function () {
+  it("should return false if not removed for unknown origin", () => {
     const event = "the event";
     const origin = "https://example.com";
     const fn = jest.fn();

--- a/spec/unit/off.spec.ts
+++ b/spec/unit/off.spec.ts
@@ -1,5 +1,5 @@
 import { subscribers } from "../../src/lib/constants";
-import bus = require("../../src/");
+import Framebus = require("../../src/");
 
 describe("off", () => {
   it("should remove subscriber given event and origin", () => {
@@ -10,7 +10,9 @@ describe("off", () => {
     subscribers[origin] = {};
     subscribers[origin][event] = [jest.fn(), fn];
 
-    bus.target(origin).off(event, fn);
+    Framebus.target({
+      origin,
+    }).off(event, fn);
 
     expect(subscribers[origin][event]).not.toContain(fn);
     expect(subscribers[origin][event].length).toBe(1);
@@ -24,7 +26,9 @@ describe("off", () => {
     subscribers[origin] = {};
     subscribers[origin][event] = [jest.fn(), fn];
 
-    bus.target(origin).off(event, fn);
+    Framebus.target({
+      origin,
+    }).off(event, fn);
 
     expect(subscribers[origin][event].length).toBe(1);
   });
@@ -37,7 +41,9 @@ describe("off", () => {
     subscribers[origin] = {};
     subscribers[origin][event] = [jest.fn(), fn];
 
-    const actual = bus.target(origin).off(event, fn);
+    const actual = Framebus.target({
+      origin,
+    }).off(event, fn);
 
     expect(actual).toBe(true);
   });
@@ -50,7 +56,9 @@ describe("off", () => {
     subscribers[origin] = {};
     subscribers[origin][event] = [jest.fn(), fn];
 
-    const actual = bus.target(origin).off("another event", fn);
+    const actual = Framebus.target({
+      origin,
+    }).off("another event", fn);
 
     expect(actual).toBe(false);
   });
@@ -63,7 +71,9 @@ describe("off", () => {
     subscribers[origin] = {};
     subscribers[origin][event] = [jest.fn(), fn];
 
-    const actual = bus.target("https://another.domain").off(event, fn);
+    const actual = Framebus.target({
+      origin: "https://another.domain",
+    }).off(event, fn);
 
     expect(actual).toBe(false);
   });

--- a/spec/unit/on.spec.ts
+++ b/spec/unit/on.spec.ts
@@ -1,8 +1,8 @@
 import { subscribers } from "../../src/lib/constants";
 import bus = require("../../src/");
 
-describe("on", function () {
-  it("should add subscriber to given event and origin", function () {
+describe("on", () => {
+  it("should add subscriber to given event and origin", () => {
     const event = "event name";
     const origin = "https://example.com";
     const fn = jest.fn();
@@ -12,7 +12,7 @@ describe("on", function () {
     expect(subscribers[origin][event]).toEqual(expect.arrayContaining([fn]));
   });
 
-  it("should add subscriber to given event and * origin if origin not given", function () {
+  it("should add subscriber to given event and * origin if origin not given", () => {
     const event = "event name";
     const fn = jest.fn();
 

--- a/spec/unit/on.spec.ts
+++ b/spec/unit/on.spec.ts
@@ -1,13 +1,23 @@
 import { subscribers } from "../../src/lib/constants";
-import bus = require("../../src/");
+import Framebus = require("../../src/");
 
 describe("on", () => {
+  let bus: Framebus;
+
+  beforeEach(() => {
+    bus = new Framebus();
+  });
+
   it("should add subscriber to given event and origin", () => {
     const event = "event name";
     const origin = "https://example.com";
     const fn = jest.fn();
 
-    bus.target(origin).on(event, fn);
+    bus
+      .target({
+        origin,
+      })
+      .on(event, fn);
 
     expect(subscribers[origin][event]).toEqual(expect.arrayContaining([fn]));
   });

--- a/spec/unit/package-payload.spec.ts
+++ b/spec/unit/package-payload.spec.ts
@@ -2,8 +2,8 @@ import { packagePayload } from "../../src/lib/package-payload";
 
 const messagePrefix = "/*framebus*/";
 
-describe("packagePayload", function () {
-  it("should add event to payload", function () {
+describe("packagePayload", () => {
+  it("should add event to payload", () => {
     const expected = "event name";
 
     const result = packagePayload(expected, "*", {});
@@ -12,7 +12,7 @@ describe("packagePayload", function () {
     expect(actual).toBe(expected);
   });
 
-  it("should add data to payload", function () {
+  it("should add data to payload", () => {
     const expected = { some: "data" };
 
     const result = packagePayload("event", "*", expected);
@@ -21,7 +21,7 @@ describe("packagePayload", function () {
     expect(actual.eventData).toEqual(expected);
   });
 
-  it("should add reply to payload if provided", function () {
+  it("should add reply to payload if provided", () => {
     const result = packagePayload("event", "*", {}, jest.fn());
     const actual = JSON.parse(result.replace(messagePrefix, ""));
 
@@ -29,11 +29,11 @@ describe("packagePayload", function () {
     expect(actual.eventData).toEqual({});
   });
 
-  it("should throw error with prefix text when element cannot be stringified", function () {
+  it("should throw error with prefix text when element cannot be stringified", () => {
     const payload = {};
 
     Object.defineProperty(payload, "prop", {
-      get: function () {
+      get() {
         throw new Error("Cross-origin denied");
       },
       enumerable: true,

--- a/spec/unit/subscribe-replier.spec.ts
+++ b/spec/unit/subscribe-replier.spec.ts
@@ -1,21 +1,21 @@
 import { subscribers } from "../../src/lib/constants";
 import { subscribeReplier } from "../../src/lib/subscribe-replier";
 
-describe("subscribeReplier", function () {
-  it("should return UUID of reply event", function () {
+describe("subscribeReplier", () => {
+  it("should return UUID of reply event", () => {
     const actual = subscribeReplier(jest.fn(), "*");
 
     expect(actual).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
   });
 
-  it("should subscribe function to returned event", function () {
+  it("should subscribe function to returned event", () => {
     const origin = "http://example.com";
     const event = subscribeReplier(jest.fn(), origin);
 
     expect(subscribers[origin][event][0]).toBeInstanceOf(Function);
   });
 
-  it("should unsubscribe function when reply invoked", function () {
+  it("should unsubscribe function when reply invoked", () => {
     const origin = "http://example.com";
     const event = subscribeReplier(jest.fn(), origin);
 

--- a/spec/unit/subscription-args-invalid.spec.ts
+++ b/spec/unit/subscription-args-invalid.spec.ts
@@ -1,20 +1,20 @@
 import { subscriptionArgsInvalid } from "../../src/lib/subscription-args-invalid";
 
-describe("subscriptionArgsInvalid", function () {
-  it("should return false for valid types", function () {
+describe("subscriptionArgsInvalid", () => {
+  it("should return false for valid types", () => {
     const actual = subscriptionArgsInvalid("event", jest.fn(), "*");
 
     expect(actual).toBe(false);
   });
 
-  it("should return true if event is not string", function () {
+  it("should return true if event is not string", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actual = subscriptionArgsInvalid({} as any, jest.fn(), "*");
 
     expect(actual).toBe(true);
   });
 
-  it("should return true if fn is not function", function () {
+  it("should return true if fn is not function", () => {
     const actual = subscriptionArgsInvalid(
       "event",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,7 +25,7 @@ describe("subscriptionArgsInvalid", function () {
     expect(actual).toBe(true);
   });
 
-  it("should return true if origin is not string", function () {
+  it("should return true if origin is not string", () => {
     const actual = subscriptionArgsInvalid("event", jest.fn(), {
       event: "object",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/spec/unit/unpack-payload.spec.ts
+++ b/spec/unit/unpack-payload.spec.ts
@@ -11,22 +11,22 @@ function makeEvent(options: MessageEventInit): MessageEvent {
   return new MessageEvent("foo", options);
 }
 
-describe("_unpackPayload", function () {
-  it("should return false if unparsable", function () {
+describe("_unpackPayload", () => {
+  it("should return false if unparsable", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actual = unpackPayload({ data: "}{" } as any);
 
     expect(actual).toBe(false);
   });
 
-  it("should return false if not prefixed", function () {
+  it("should return false if not prefixed", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actual = unpackPayload({ data: JSON.stringify({}) } as any);
 
     expect(actual).toBe(false);
   });
 
-  it("should return event and args in payload", function () {
+  it("should return event and args in payload", () => {
     const event = "event name";
     const data = { data: "some data" };
     const actual = unpackPayload(
@@ -40,7 +40,7 @@ describe("_unpackPayload", function () {
     expect(eventData).toEqual(data);
   });
 
-  it("should return event and args and reply in payload", function () {
+  it("should return event and args and reply in payload", () => {
     const event = "event name";
     const reply = "123129085-4234-1231-99887877";
     const data = { data: "some data" };
@@ -58,7 +58,7 @@ describe("_unpackPayload", function () {
     expect(eventData.data).toBe("some data");
   });
 
-  it("the source should postMessage the payload to the origin when reply is called", function () {
+  it("the source should postMessage the payload to the origin when reply is called", () => {
     const fakeSource = {
       ...(window as Window),
       postMessage: jest.fn(),
@@ -86,7 +86,7 @@ describe("_unpackPayload", function () {
     expect(fakeSource.postMessage).toBeCalledWith(expect.any(String), "origin");
   });
 
-  it("the source should not attempt to postMessage the payload to the origin if no source available", function () {
+  it("the source should not attempt to postMessage the payload to the origin if no source available", () => {
     const reply = "123129085-4234-1231-99887877";
     const data = { data: "some data" };
     const actual = unpackPayload(
@@ -103,7 +103,7 @@ describe("_unpackPayload", function () {
     ) as FramebusPayload;
     const handler = actual.reply as FramebusSubscribeHandler;
 
-    expect(function () {
+    expect(() => {
       handler({});
     }).not.toThrowError();
   });

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -20,14 +20,12 @@ type VerifyDomainMethod = (domain: string) => boolean;
 type FramebusOptions = {
   channel?: string;
   origin?: string;
-  parentUrl?: string;
   verifyDomain?: VerifyDomainMethod;
 };
 
 export class Framebus {
   origin: string;
   channel: string;
-  parentUrl: string;
 
   private verifyDomain?: VerifyDomainMethod;
   private isDestroyed: boolean;
@@ -36,7 +34,6 @@ export class Framebus {
   constructor(options: FramebusOptions = {}) {
     this.origin = options.origin || "*";
     this.channel = options.channel || "";
-    this.parentUrl = options.parentUrl || "";
     this.verifyDomain = options.verifyDomain;
 
     this.isDestroyed = false;
@@ -118,7 +115,7 @@ export class Framebus {
       return false;
     }
 
-    if (this.parentUrl) {
+    if (this.verifyDomain) {
       /* eslint-disable no-invalid-this, @typescript-eslint/ban-ts-comment */
       handler = function (...args) {
         // @ts-ignore
@@ -149,7 +146,7 @@ export class Framebus {
       return false;
     }
 
-    if (this.parentUrl) {
+    if (this.verifyDomain) {
       for (let i = 0; i < this.listeners.length; i++) {
         const listener = this.listeners[i];
 
@@ -202,7 +199,7 @@ export class Framebus {
     let merchantHost;
     const a = document.createElement("a");
 
-    a.href = this.parentUrl;
+    a.href = location.href;
 
     if (a.protocol === "https:") {
       merchantHost = a.host.replace(/:443$/, "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import { attach } from "./lib/attach";
 import { Framebus } from "./framebus";
 
-const bus = new Framebus();
-
 attach();
 
-export = bus;
+export = Framebus;

--- a/src/lib/subscribe-replier.ts
+++ b/src/lib/subscribe-replier.ts
@@ -14,10 +14,14 @@ export function subscribeReplier(
     replyOriginHandler: FramebusSubscribeHandler
   ): void {
     fn(data, replyOriginHandler);
-    Framebus.target(origin).off(uuid, replier);
+    Framebus.target({
+      origin,
+    }).off(uuid, replier);
   }
 
-  Framebus.target(origin).on(uuid, replier);
+  Framebus.target({
+    origin,
+  }).on(uuid, replier);
 
   return uuid;
 }


### PR DESCRIPTION
This essentially moves the wrapper we use in braintree-web to scope events with framebus and moves it directly to framebus: https://github.com/braintree/braintree-web/blob/master/src/lib/bus/index.js