### PR TITLE
Fix #41: do not broadcast to frames we opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3651,9 +3651,9 @@
       }
     },
     "chromedriver": {
-      "version": "85.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-85.0.1.tgz",
-      "integrity": "sha512-z8je3U4tXFZnx7AloRabM4Ep1lpFJvHxLoGuRvLg33Qy0UKk/z6OXmHUO2z6DKE0Oe6CFpjj/bdhuQ8dfvq9ug==",
+      "version": "87.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.0.tgz",
+      "integrity": "sha512-PY7FnHOQKfH0oPfSdhpLx5nEy5g4dGYySf2C/WZGkAaCaldYH8/3lPPucZ8MlOCi4bCSGoKoCUTeG6+wYWavvw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -3666,18 +3666,18 @@
       },
       "dependencies": {
         "agent-base": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -6052,12 +6052,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -11622,9 +11616,9 @@
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stdout": {
@@ -14056,6 +14050,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@wdio/sync": "^6.5.0",
     "async": "^3.2.0",
     "browserify": "^16.5.2",
-    "chromedriver": "^85.0.1",
+    "chromedriver": "^87.0.0",
     "del": "^6.0.0",
     "ejs": "^3.1.5",
     "eslint": "^7.10.0",

--- a/spec/functional/popup-spec.js
+++ b/spec/functional/popup-spec.js
@@ -37,6 +37,7 @@ describe("Popup Events", () => {
     );
     const actual = $("p").getText();
 
+    expect($$("p").length).toBe(1);
     expect(actual).toBe(expected);
   });
 
@@ -72,6 +73,7 @@ describe("Popup Events", () => {
     );
     const actual = $("p").getText();
 
+    expect($$("p").length).toBe(1);
     expect(actual).toContain(expected);
   });
 
@@ -107,6 +109,41 @@ describe("Popup Events", () => {
     );
     const actual = $("p").getText();
 
+    expect($$("p").length).toBe(1);
+    expect(actual).not.toContain("FAILURE");
+  });
+
+  it("should be able to receive messages from opener window", () => {
+    const expected = "hello from opener!";
+
+    $("#open-popup").click();
+    browser.switchWindow("popup");
+    browser.waitUntil(
+      () => {
+        return $("body").getHTML() != null;
+      },
+      {
+        timeout: 1000,
+        timeoutMsg: "expected body to exist",
+      }
+    );
+
+    browser.switchWindow("localhost:3099");
+    $("#from-top-message").setValue(expected);
+    $("#send-from-top").click();
+
+    browser.switchWindow("popup");
+    browser.waitUntil(
+      () => {
+        return $("p").getHTML !== "";
+      },
+      {
+        timeout: 1000,
+      }
+    );
+    const actual = $("p").getText();
+
+    expect($$("p").length).toBe(1);
     expect(actual).not.toContain("FAILURE");
   });
 });

--- a/spec/functional/public/html/popup.html
+++ b/spec/functional/public/html/popup.html
@@ -34,6 +34,17 @@
           app.printToDOM('FAILURE received "from-popup" multiple times');
         }
       });
+
+      var countFromTop = 0;
+      bus.on("from-top", function (data) {
+        countFromTop++;
+
+        if (countFromTop > 1) {
+          app.printToDOM('FAILURE received "from-top" multiple times');
+        } else {
+          app.printToDOM(data.message);
+        }
+      });
     </script>
   </body>
 </html>

--- a/spec/functional/public/index.html
+++ b/spec/functional/public/index.html
@@ -12,7 +12,9 @@
       src="http://<%= domain %>:<%= port2 %>/html/frame3.html"
       name="frame3"
     ></iframe>
+    <input id="from-top-message" />
     <button id="open-popup">Open popup</button>
+    <button id="send-from-top">Send from top</button>
 
     <script>
       window.name = "root-frame";
@@ -24,6 +26,16 @@
       bus.on("Marco", function () {
         app.printToDOM('FAIL: [index] received "Marco"');
       });
+
+      document.querySelector("#send-from-top").addEventListener(
+        "click",
+        function () {
+          bus.emit("from-top", {
+            message: document.querySelector("#from-top-message").value,
+          });
+        },
+        false
+      );
 
       document.querySelector("#open-popup").addEventListener(
         "click",

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -11,7 +11,7 @@ export function broadcast(
   try {
     frame.postMessage(payload, origin);
 
-    if (hasOpener(frame)) {
+    if (hasOpener(frame) && frame.opener.top !== window.top) {
       broadcast(frame.opener.top, payload, origin);
     }
 


### PR DESCRIPTION
Fixes #41 Did a bit of testing and the fix I suggested seems to work out.

First I was trying to add a unit test for this, but that did not work out since it's not a real browser environment.

So I added a functional test to `popup-spec.js` that fails without the fix. I also added another expectation to the other tests in `popup-spec.js` that makes them all fail without the fix -- that they receive the message only once. The were many `<p>` elements being created which tests failed to detect. With the fix, all tests pass again.