### PR TITLE
feat: add emitAsPromise method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 
 - Fix issue where emitting to new window could cause an infinite loop (closes #41, thanks @blutorange)
+- Add `emitAsPromise` as convenience method when waiting for replies from `emit` calls
+- Add `setPromise` static method for easy polyfilling environments that do not support promises
 
 # 5.0.0
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ framebus
 | --------- | --------------- | ---------------------------------- |
 | `options` | FramebusOptions | See above section for more details |
 
-#### `emit('event', data? , callback?): boolean`
+#### `emit('event', data?, callback?): boolean`
 
 **returns**: `true` if the event was successfully published, `false` otherwise
 
@@ -80,6 +80,24 @@ framebus
 | `event`          | String   | The name of the event                                |
 | `data`           | Object   | The data to give to subscribers                      |
 | `callback(data)` | Function | Give subscribers a function for easy, direct replies |
+
+#### `emitAsPromise('event', data?): Promise`
+
+**returns**: A promise that resolves when the emitted event is responded to the first time. It will reject if the event could not be succesfully published.
+
+| Argument | Type   | Description                     |
+|----------|--------|---------------------------------|
+| `event`  | String | The name of the event           |
+| `data`   | Object | The data to give to subscribers |
+
+Using this method assumes the browser context you are using supports Promises. If it does not, set a polyfill for the Framebus class with `setPromise`
+
+```js
+// or however you want to polyfill the promise
+const PolyfilledPromise = require("promise-polyfill");
+
+Framebus.setPromise(PolyfilledPromise);
+```
 
 #### `on('event', fn): boolean`
 

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -40,6 +40,12 @@ export class Framebus {
     this.listeners = [];
   }
 
+  static Promise = Promise;
+
+  static setPromise(PromiseGlobal: typeof Framebus["Promise"]): void {
+    Framebus.Promise = PromiseGlobal;
+  }
+
   static target(options?: FramebusOptions): Framebus {
     return new Framebus(options);
   }
@@ -97,6 +103,21 @@ export class Framebus {
     broadcast(window.top || window.self, payload, origin);
 
     return true;
+  }
+
+  emitAsPromise<T = void>(
+    eventName: string,
+    data?: FramebusSubscriberArg
+  ): Promise<T> {
+    return new Framebus.Promise((resolve, reject) => {
+      const didAttachListener = this.emit(eventName, data, (payload) => {
+        resolve(payload as T);
+      });
+
+      if (!didAttachListener) {
+        reject(new Error(`Listener not added for "${eventName}"`));
+      }
+    });
   }
 
   on(eventName: string, originalHandler: FramebusOnHandler): boolean {


### PR DESCRIPTION
This should make using framebus within standalone modules that only ever expect emit to be replied to once easier.

Worked on this with @billwerges 