### PR TITLE
Add trailing slash to verifyDomain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If a `verifyDomain` is passed, then the `on` listener will only fire if the doma
 var bus = new Framebus({
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
-    url.indexOf("https://my-domain") === 0;
+    url.indexOf("https://my-domain/") === 0;
   },
 });
 ```


### PR DESCRIPTION
If someone blindly uses this example they might open themself to potential attacks, since an attacker can use a domain like `https://my-domain.evil.com` , adding a trailing slash solves the issue