### PR TITLE
fix: silence unnecessary console.errors when broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,161 +1,198 @@
+# unreleased
+
+  - Elimate unnecessary `console.error`s from sibling iframes on the
+    same domain when targetting a specific domain
+
 # 5.1.2
 
-- Fix issue where framebus could not be used with server side rendering
+  - Fix issue where framebus could not be used with server side
+    rendering
 
 # 5.1.1
 
-- Fix issue where Internet Explorer would error because Promise is not defined
+  - Fix issue where Internet Explorer would error because Promise is not
+    defined
 
 # 5.1.0
 
-- Fix issue where emitting to new window could cause an infinite loop (closes #41, thanks @blutorange)
-- Add `emitAsPromise` as convenience method when waiting for replies from `emit` calls
-- Add `setPromise` static method for easy polyfilling environments that do not support promises
+  - Fix issue where emitting to new window could cause an infinite loop
+    (closes \#41, thanks @blutorange)
+  - Add `emitAsPromise` as convenience method when waiting for replies
+    from `emit` calls
+  - Add `setPromise` static method for easy polyfilling environments
+    that do not support promises
 
 # 5.0.0
 
-- Allow scoping to a specific channel for events
+  - Allow scoping to a specific channel for events
+    
+    ``` js
+    var bus = new Framebus({
+      channel: "some-unique-identifier-used-on-both-the-parent-and-child-pages",
+    });
+    ```
 
-  ```js
-  var bus = new Framebus({
-    channel: "some-unique-identifier-used-on-both-the-parent-and-child-pages",
-  });
-  ```
+  - Add `verifyDomain` config to scope messages to specific domains
+    
+    ``` js
+    var bus = new Framebus({
+      verifyDomain: function (url) {
+        // only listens for events emitted from `https://parent-url.example.com` and `https://my-domain.example.com`
+        return url.indexOf("https://my-domain.example.com");
+      },
+    });
+    ```
 
-- Add `verifyDomain` config to scope messages to specific domains
-  ```js
-  var bus = new Framebus({
-    verifyDomain: function (url) {
-      // only listens for events emitted from `https://parent-url.example.com` and `https://my-domain.example.com`
-      return url.indexOf("https://my-domain.example.com");
-    },
-  });
-  ```
-- Add `teardown` method for easy cleanup
+  - Add `teardown` method for easy cleanup
 
-_Breaking Changes_
+*Breaking Changes*
 
-- Instantiate new instances of framebus
+  - Instantiate new instances of framebus
+    
+    ``` js
+    // v4
+    var bus = require("framebus");
+    bus.on(/* args */);
+    bus.emit(/* args */);
+    
+    // v5
+    var Framebus = require("framebus");
+    var bus = new Framebus();
+    bus.on(/* args */);
+    bus.emit(/* args */);
+    ```
 
-  ```js
-  // v4
-  var bus = require("framebus");
-  bus.on(/* args */);
-  bus.emit(/* args */);
-
-  // v5
-  var Framebus = require("framebus");
-  var bus = new Framebus();
-  bus.on(/* args */);
-  bus.emit(/* args */);
-  ```
-
-- Instantiating a framebus with `target` method with an `origin` param now requires an options object (same object that is used to instantiate the instance)
-
-  ```js
-  // v4
-  var bus = require("framebus");
-  var anotherBus = bus.target("example.com");
-
-  // v5
-  var Framebus = require("framebus");
-  var bus = Framebus.target({
-    origin: "example.com",
-  });
-  var anotherBus = bus.target({
-    origin: "example.com",
-  });
-  ```
+  - Instantiating a framebus with `target` method with an `origin` param
+    now requires an options object (same object that is used to
+    instantiate the instance)
+    
+    ``` js
+    // v4
+    var bus = require("framebus");
+    var anotherBus = bus.target("example.com");
+    
+    // v5
+    var Framebus = require("framebus");
+    var bus = Framebus.target({
+      origin: "example.com",
+    });
+    var anotherBus = bus.target({
+      origin: "example.com",
+    });
+    ```
 
 # 4.0.5
 
-- Fixup Framebus typing for Typescript integrations
+  - Fixup Framebus typing for Typescript integrations
 
 # v4.0.3 and v4.0.4
 
-- Use `@braintree/uuid` package for uuid generation
-- Update typescript to v4
+  - Use `@braintree/uuid` package for uuid generation
+  - Update typescript to v4
 
 # v4.0.2
 
-- Fix issue where rollup bundlers could not import framebus (see [braintree-web#504](https://github.com/braintree/braintree-web/issues/504))
+  - Fix issue where rollup bundlers could not import framebus (see
+    [braintree-web\#504](https://github.com/braintree/braintree-web/issues/504))
 
 # v4.0.1
 
-- Fix issue where framebus could not be used with server side rendering
+  - Fix issue where framebus could not be used with server side
+    rendering
 
 # v4.0.0
 
-_Breaking Changes_
+*Breaking Changes*
 
-- Drop support for IE < 9
-- Drop support for using methods standalone without using the bus
-- Drop `publish`, `pub`, and `trigger` methods. Use `emit`
-- Drop `subscribe` and `sub` methods. Use `on`
-- Drop `unsubscribe` and `unsub` methods. Use `off`
-- Drop support for passing multiple arguments to `emit`, not it only supports passing `data` and `reply`
+  - Drop support for IE \< 9
+  - Drop support for using methods standalone without using the bus
+  - Drop `publish`, `pub`, and `trigger` methods. Use `emit`
+  - Drop `subscribe` and `sub` methods. Use `on`
+  - Drop `unsubscribe` and `unsub` methods. Use `off`
+  - Drop support for passing multiple arguments to `emit`, not it only
+    supports passing `data` and `reply`
 
 # 3.0.2
 
-- Fix issue where framebus would error when trying to reply to a non-existent window/frame
+  - Fix issue where framebus would error when trying to reply to a
+    non-existent window/frame
+    
+    # 3.0.1
 
-  # 3.0.1
+  - Fix issue where broadcasts to frames would fail if parent page has
+    overwritten the window.length variable
+    
+    # 3.0.0
 
-- Fix issue where broadcasts to frames would fail if parent page has overwritten the window.length variable
+*BREAKING CHANGES*
 
-  # 3.0.0
+  - Module is now CommonJS only, and must be used with npm with a build
+    tool (Browserify, Webpack, etc)
 
-_BREAKING CHANGES_
+  - Bower support dropped
+    
+    # 2.0.8
 
-- Module is now CommonJS only, and must be used with npm with a build tool (Browserify, Webpack, etc)
-- Bower support dropped
+  - Fall back to `window.self` when `window.top` is undefined in old
+    versions of IE.
+    
+    # 2.0.7
 
-  # 2.0.8
+  - Corrects a regression introduced in 2.0.6 that prevented CommonJS
+    runtimes from working.
+    
+    # 2.0.6
 
-- Fall back to `window.self` when `window.top` is undefined in old versions of IE.
+  - framebus can be required (but not executed) from Node.js®
+    environments.
+    
+    # 2.0.5
 
-  # 2.0.7
+  - Only traverse to `opener` from the top-level frame
+    
+    # 2.0.4
 
-- Corrects a regression introduced in 2.0.6 that prevented CommonJS runtimes from working.
+  - Avoid exceptions while broadcasting events
+    
+    # 2.0.3
 
-  # 2.0.6
+  - Do not infinitely recurse when `window.opener === window`
+    
+    # 2.0.2
 
-- framebus can be required (but not executed) from Node.js® environments.
-
-  # 2.0.5
-
-- Only traverse to `opener` from the top-level frame
-
-  # 2.0.4
-
-- Avoid exceptions while broadcasting events
-
-  # 2.0.3
-
-- Do not infinitely recurse when `window.opener === window`
-
-  # 2.0.2
-
-[unpublished]
+\[unpublished\]
 
 # 2.0.1
 
-- Do not throw exceptions `window.opener` existed but has already closed.
-- Do not throw exceptions when a `frame.postMessage` is denied.
-- Exceptions are no longer thrown when `publish`, `subscribe` or `unsubscribe` were invoked directly.
+  - Do not throw exceptions `window.opener` existed but has already
+    closed.
 
-  ```javascript
-  var publish = framebus.publish;
-  publish("event");
-  ```
+  - Do not throw exceptions when a `frame.postMessage` is denied.
 
-  # 2.0.0
+  - Exceptions are no longer thrown when `publish`, `subscribe` or
+    `unsubscribe` were invoked directly.
+    
+    ``` javascript
+    var publish = framebus.publish;
+    publish("event");
+    ```
+    
+    # 2.0.0
 
-- Breaking change: use of `origin` as a parameter for `publish`, `subscribe` and `unsubscribe` has been moved to the chaining-function `target(origin)`
-- Added feature: events can be published with multiple arguments. If the last argument is a function, it is treated as a callback that subscribers can call.
-- Added feature: `include(popup)` adds popups to the listing of frames to be messaged.
-- Added feature: `window.opener` will now be included in framebus messaging, if available.
+  - Breaking change: use of `origin` as a parameter for `publish`,
+    `subscribe` and `unsubscribe` has been moved to the
+    chaining-function `target(origin)`
 
-  # 1.0.0
+  - Added feature: events can be published with multiple arguments. If
+    the last argument is a function, it is treated as a callback that
+    subscribers can call.
 
-- Initial release
+  - Added feature: `include(popup)` adds popups to the listing of frames
+    to be messaged.
+
+  - Added feature: `window.opener` will now be included in framebus
+    messaging, if available.
+    
+    # 1.0.0
+
+  - Initial release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Framebus [![Build Status](https://github.com/braintree/framebus/workflows/Unit%20Tests/badge.svg)](https://github.com/braintree/framebus/actions?query=workflow%3A%22Unit+Tests%22) [![Build Status](https://github.com/braintree/framebus/workflows/Functional%20Tests/badge.svg)](https://github.com/braintree/framebus/actions?query=workflow%3A%22Functional+Tests%22) [![npm version](https://badge.fury.io/js/framebus.svg)](http://badge.fury.io/js/framebus)
 
-Framebus allows you to easily send messages across frames (and iframes) with a simple bus.
+Framebus allows you to easily send messages across frames (and iframes)
+with a simple bus.
 
 In one frame:
 
-```js
+``` js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -16,7 +17,7 @@ bus.emit("message", {
 
 In another frame:
 
-```js
+``` js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -25,9 +26,10 @@ bus.on("message", function (data) {
 });
 ```
 
-The Framebus class takes a configuration object, where all the params are optional.
+The Framebus class takes a configuration object, where all the params
+are optional.
 
-```js
+``` js
 type FramebusOptions = {
   origin?: string, // default: "*"
   channel?: string, // no default
@@ -35,13 +37,35 @@ type FramebusOptions = {
 };
 ```
 
-The `origin` sets the framebus instance to only operate on the chosen origin.
+The `origin` sets the framebus instance to only operate on the chosen
+origin. By default, the origin is set to `*`, which indicates all
+windows should recieve the messages.
 
-The `channel` namespaces the events called with `on` and `emit` so you can have multiple bus instances on the page and have them only communicate with busses with the same channel value.
+> **Note:** When `postMessage` is called on a frame that doesn't match
+> the `origin` provided, a benign `console.error` will be presented in
+> the browser's developer tools alerting the developer that the
+> `postMessage` failed because the `origin` did not match. If a child
+> frame targetting the `origin` of it's parent frame has sibling frames
+> on the parent page, this library will automatically skip `postMessage`
+> calls to them when the sibling iframe's domain is the same as the
+> frame issuing the `postMessage` and the `origin` does not match the
+> provided origin. This will reduce the number of unnecessary
+> `console.error`s in the browser's developer tools console. If the
+> sibling iframe is on a different domain, the library does not have
+> access to the frame's `origin` and must attempt to `postMessage` to
+> it, just in case it's `origin` does match the provided one. If the
+> `origin` does not match, that will result in a benign `console.error`
+> about it.
 
-If a `verifyDomain` is passed, then the `on` listener will only fire if the domain of the origin of the post message matches the `location.href` value of page or the function passed for `verifyDomain` returns `true`.
+The `channel` namespaces the events called with `on` and `emit` so you
+can have multiple bus instances on the page and have them only
+communicate with busses with the same channel value.
 
-```js
+If a `verifyDomain` is passed, then the `on` listener will only fire if
+the domain of the origin of the post message matches the `location.href`
+value of page or the function passed for `verifyDomain` returns `true`.
+
+``` js
 var bus = new Framebus({
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
@@ -54,11 +78,14 @@ var bus = new Framebus({
 
 #### `target(options: FramebusOptions): framebus`
 
-**returns**: a chainable instance of framebus that operates on the chosen origin.
+**returns**: a chainable instance of framebus that operates on the
+chosen origin.
 
-This method is used in conjuction with `emit`, `on`, and `off` to restrict their results to the given origin. By default, an origin of `'*'` is used.
+This method is used in conjuction with `emit`, `on`, and `off` to
+restrict their results to the given origin. By default, an origin of
+`'*'` is used.
 
-```javascript
+``` javascript
 framebus
   .target({
     origin: "https://example.com",
@@ -73,7 +100,8 @@ framebus
 
 #### `emit('event', data?, callback?): boolean`
 
-**returns**: `true` if the event was successfully published, `false` otherwise
+**returns**: `true` if the event was successfully published, `false`
+otherwise
 
 | Argument         | Type     | Description                                          |
 | ---------------- | -------- | ---------------------------------------------------- |
@@ -83,16 +111,20 @@ framebus
 
 #### `emitAsPromise('event', data?): Promise`
 
-**returns**: A promise that resolves when the emitted event is responded to the first time. It will reject if the event could not be succesfully published.
+**returns**: A promise that resolves when the emitted event is responded
+to the first time. It will reject if the event could not be succesfully
+published.
 
 | Argument | Type   | Description                     |
 | -------- | ------ | ------------------------------- |
 | `event`  | String | The name of the event           |
 | `data`   | Object | The data to give to subscribers |
 
-Using this method assumes the browser context you are using supports Promises. If it does not, set a polyfill for the Framebus class with `setPromise`
+Using this method assumes the browser context you are using supports
+Promises. If it does not, set a polyfill for the Framebus class with
+`setPromise`
 
-```js
+``` js
 // or however you want to polyfill the promise
 const PolyfilledPromise = require("promise-polyfill");
 
@@ -101,10 +133,12 @@ Framebus.setPromise(PolyfilledPromise);
 
 #### `on('event', fn): boolean`
 
-**returns**: `true` if the subscriber was successfully added, `false` otherwise
+**returns**: `true` if the subscriber was successfully added, `false`
+otherwise
 
-Unless already bound to a scope, the listener will be executed with `this` set
-to the `MessageEvent` received over postMessage.
+Unless already bound to a scope, the listener will be executed with
+`this` set to the `MessageEvent` received over
+postMessage.
 
 | Argument               | Type     | Description                                                 |
 | ---------------------- | -------- | ----------------------------------------------------------- |
@@ -114,7 +148,8 @@ to the `MessageEvent` received over postMessage.
 
 #### `off('event', fn): boolean`
 
-**returns**: `true` if the subscriber was successfully removed, `false` otherwise
+**returns**: `true` if the subscriber was successfully removed, `false`
+otherwise
 
 | Argument | Type     | Description                      |
 | -------- | -------- | -------------------------------- |
@@ -123,9 +158,10 @@ to the `MessageEvent` received over postMessage.
 
 #### `include(popup): boolean`
 
-**returns**: `true` if the popup was successfully included, `false` otherwise
+**returns**: `true` if the popup was successfully included, `false`
+otherwise
 
-```javascript
+``` javascript
 var popup = window.open("https://example.com");
 
 framebus.include(popup);
@@ -138,9 +174,10 @@ framebus.emit("hello popup and friends!");
 
 #### `teardown(): void`
 
-Calls `off` on all listeners used for this bus instance and makes subsequent calls to all methods `noop`.
+Calls `off` on all listeners used for this bus instance and makes
+subsequent calls to all methods `noop`.
 
-```javascript
+``` javascript
 bus.on("event-name", handler);
 
 // event-name listener is torn down
@@ -154,70 +191,79 @@ bus.off("event-name", handler);
 
 ## Pitfalls
 
-These are some things to keep in mind while using **framebus** to handle your
-event delegation
+These are some things to keep in mind while using **framebus** to handle
+your event delegation
 
 ### Cross-site scripting (XSS)
 
-**framebus** allows convenient event delegation across iframe borders. By
-default it will broadcast events to all iframes on the page, regardless of
-origin. Use the optional `target()` method when you know the exact domain of
-the iframes you are communicating with. This will protect your event data from
-malicious domains.
+**framebus** allows convenient event delegation across iframe borders.
+By default it will broadcast events to all iframes on the page,
+regardless of origin. Use the optional `target()` method when you know
+the exact domain of the iframes you are communicating with. This will
+protect your event data from malicious domains.
 
 ### Data is serialized as JSON
 
-**framebus** operates over `postMessage` using `JSON.parse` and `JSON.stringify`
-to facilitate message data passing. Keep in mind that not all JavaScript objects
-serialize cleanly into and out of JSON, such as `undefined`.
+**framebus** operates over `postMessage` using `JSON.parse` and
+`JSON.stringify` to facilitate message data passing. Keep in mind that
+not all JavaScript objects serialize cleanly into and out of JSON, such
+as `undefined`.
 
 ### Asynchronicity
 
-Even when the subscriber and publisher are within the same frame, events go
-through `postMessage`. Keep in mind that `postMessage` is an asynchronous
-protocol and that publication and subscription handling occur on separate
-iterations of the [event
-loop (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/EventLoop#Event_loop).
+Even when the subscriber and publisher are within the same frame, events
+go through `postMessage`. Keep in mind that `postMessage` is an
+asynchronous protocol and that publication and subscription handling
+occur on separate iterations of the [event loop
+(MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/EventLoop#Event_loop).
 
 ### Published callback functions are an abstraction
 
-When you specify a `callback` while using `emit`, the function is not actually
-given to the subscriber. The subscriber receives a one-time-use function that is
-generated locally by the subscriber's **framebus**. This one-time-use callback function
-is pre-configured to publish an event back to the event origin's domain using a
-[UUID](http://tools.ietf.org/html/rfc4122) as the event name. The events occur
-as follows:
+When you specify a `callback` while using `emit`, the function is not
+actually given to the subscriber. The subscriber receives a one-time-use
+function that is generated locally by the subscriber's **framebus**.
+This one-time-use callback function is pre-configured to publish an
+event back to the event origin's domain using a
+[UUID](http://tools.ietf.org/html/rfc4122) as the event name. The events
+occur as follows:
 
-1. `http://emitter.example.com` publishes an event with a function as the event data
+1.  `http://emitter.example.com` publishes an event with a function as
+    the event data
+    
+    ``` javascript
+    var callback = function (data) {
+      console.log("Got back %s as a reply!", data);
+    };
+    
+    framebus.emit("Marco!", callback, "http://listener.example.com");
+    ```
 
-   ```javascript
-   var callback = function (data) {
-     console.log("Got back %s as a reply!", data);
-   };
+2.  The **framebus** on `http://emitter.example.com` generates a UUID as
+    an event name and adds the `callback` as a subscriber to this event.
 
-   framebus.emit("Marco!", callback, "http://listener.example.com");
-   ```
+3.  The **framebus** on `http://listener.example.com` sees that a
+    special callback event is in the event payload. A one-time-use
+    function is created locally and given to subscribers of `'Marco!'`
+    as the event data.
 
-1. The **framebus** on `http://emitter.example.com` generates a UUID as an event name
-   and adds the `callback` as a subscriber to this event.
-1. The **framebus** on `http://listener.example.com` sees that a special callback
-   event is in the event payload. A one-time-use function is created locally and
-   given to subscribers of `'Marco!'` as the event data.
-1. The subscriber on `http://listener.example.com` uses the local one-time-use
-   callback function to send data back to the emitter's origin
+4.  The subscriber on `http://listener.example.com` uses the local
+    one-time-use callback function to send data back to the emitter's
+    origin
+    
+    ``` javascript
+    framebus
+      .target("http://emitter.example.com")
+      .on("Marco!", function (callback) {
+        callback("Polo!");
+      });
+    ```
 
-   ```javascript
-   framebus
-     .target("http://emitter.example.com")
-     .on("Marco!", function (callback) {
-       callback("Polo!");
-     });
-   ```
+5.  The one-time-use function on `http://listener.example.com` publishes
+    an event as the UUID generated in **step 2** to the origin that
+    emitted the event.
 
-1. The one-time-use function on `http://listener.example.com` publishes an event
-   as the UUID generated in **step 2** to the origin that emitted the event.
-1. Back on `http://emitter.example.com`, the `callback` is called and
-   unsubscribed from the special UUID event afterward.
+6.  Back on `http://emitter.example.com`, the `callback` is called and
+    unsubscribed from the special UUID event afterward.
 
 ## Development and contributing
 

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -153,7 +153,9 @@ describe("broadcast", () => {
         get() {
           throw new Error("not allowed");
         },
-        set() {},
+        set() {
+          // noop
+        },
       });
 
       broadcast(frame, "payload", "https://not-example.com");


### PR DESCRIPTION
I figured out why we couldn't get #83 to work without flagging it, and that's because it didn't actually work at all!

The check for the frame's origin only works if you have access to the property on the frame, and that only happens if the frames are on the same domain. 

So, in short, if we can't detect the domain, we have to attempt to broadcast to it even if the origin does not match (because it's impossible for us to tell what the origin is)

For Braintree's use case, where we are primarily wanting to avoid post messaging out to our sibling frames to reduce the noise, this method will work. But if there's another 3rd party iframe on the merchant's page (and advertisement, or some other plugin), the `console.error`s will still happen and there's no way to silence it with our current implementation.

I'd like us to pursue the ask in #51 where we configure framebus to be able to `postMessage` and listen on messages from the specified frames. Something like a `targetFrames: []` option.

closes #83 