### PR TITLE
Target frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ with a simple bus.
 
 In one frame:
 
-```js
+``` js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -17,7 +17,7 @@ bus.emit("message", {
 
 In another frame:
 
-```js
+``` js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -29,12 +29,12 @@ bus.on("message", function (data) {
 The Framebus class takes a configuration object, where all the params
 are optional.
 
-```js
+``` js
 type FramebusOptions = {
   origin?: string, // default: "*"
   channel?: string, // no default
   verifyDomain?: (url: string) => boolean, // no default
-  targetFrames?: Window[], // by default, all frames available to broadcast to
+  targetFrames?: <HTMLFrameElement | Window>[], // by default, all frames available to broadcast to
 };
 ```
 
@@ -50,7 +50,7 @@ fire if the domain of the origin of the post message matches the
 `location.href` value of page or the function passed for `verifyDomain`
 returns `true`.
 
-```js
+``` js
 var bus = new Framebus({
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
@@ -60,9 +60,11 @@ var bus = new Framebus({
 ```
 
 If a `targetFrames` array is passed, then framebus will only broadcast
-to those frames and listen for messages from those frames.
+to those frames and listen for messages from those frames. You can pass
+a reference to a `Window` (the return value of `window.open`) or an
+`HTMLFrameElement` (a DOM node representing an iframe).
 
-```js
+``` js
 var myIframe = document.getElementById("my-iframe");
 
 var bus = new Framebus({
@@ -74,7 +76,7 @@ To add additional frames to the `targetFrames` array in the future, use
 the `include` method. `targetFrames` must be set, even if it's an empty
 array, for this method to work.
 
-```js
+``` js
 var myIframe = document.getElementById("my-iframe");
 
 var bus = new Framebus({
@@ -95,7 +97,7 @@ This method is used in conjuction with `emit`, `on`, and `off` to
 restrict their results to the given origin. By default, an origin of
 `'*'` is used.
 
-```javascript
+``` javascript
 framebus
   .target({
     origin: "https://example.com",
@@ -134,7 +136,7 @@ Using this method assumes the browser context you are using supports
 Promises. If it does not, set a polyfill for the Framebus class with
 `setPromise`
 
-```js
+``` js
 // or however you want to polyfill the promise
 const PolyfilledPromise = require("promise-polyfill");
 
@@ -174,7 +176,7 @@ otherwise
 If framebus was instantiated with `targetFrames`, then the popup will be
 added to the `targetFrames` array.
 
-```javascript
+``` javascript
 var popup = window.open("https://example.com");
 
 framebus.include(popup);
@@ -190,7 +192,7 @@ framebus.emit("hello popup and friends!");
 Calls `off` on all listeners used for this bus instance and makes
 subsequent calls to all methods `noop`.
 
-```javascript
+``` javascript
 bus.on("event-name", handler);
 
 // event-name listener is torn down
@@ -242,12 +244,12 @@ occur as follows:
 
 1.  `http://emitter.example.com` publishes an event with a function as
     the event data
-
-    ```javascript
+    
+    ``` javascript
     var callback = function (data) {
       console.log("Got back %s as a reply!", data);
     };
-
+    
     framebus.emit("Marco!", callback, "http://listener.example.com");
     ```
 
@@ -262,8 +264,8 @@ occur as follows:
 4.  The subscriber on `http://listener.example.com` uses the local
     one-time-use callback function to send data back to the emitter's
     origin
-
-    ```javascript
+    
+    ``` javascript
     framebus
       .target("http://emitter.example.com")
       .on("Marco!", function (callback) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ with a simple bus.
 
 In one frame:
 
-``` js
+```js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -17,7 +17,7 @@ bus.emit("message", {
 
 In another frame:
 
-``` js
+```js
 var Framebus = require("framebus");
 var bus = new Framebus();
 
@@ -29,7 +29,7 @@ bus.on("message", function (data) {
 The Framebus class takes a configuration object, where all the params
 are optional.
 
-``` js
+```js
 type FramebusOptions = {
   origin?: string, // default: "*"
   channel?: string, // no default
@@ -50,7 +50,7 @@ fire if the domain of the origin of the post message matches the
 `location.href` value of page or the function passed for `verifyDomain`
 returns `true`.
 
-``` js
+```js
 var bus = new Framebus({
   verifyDomain: function (url) {
     // only return true if the domain of the url matches exactly
@@ -64,7 +64,7 @@ to those frames and listen for messages from those frames. You can pass
 a reference to a `Window` (the return value of `window.open`) or an
 `HTMLFrameElement` (a DOM node representing an iframe).
 
-``` js
+```js
 var myIframe = document.getElementById("my-iframe");
 
 var bus = new Framebus({
@@ -76,7 +76,7 @@ To add additional frames to the `targetFrames` array in the future, use
 the `include` method. `targetFrames` must be set, even if it's an empty
 array, for this method to work.
 
-``` js
+```js
 var myIframe = document.getElementById("my-iframe");
 
 var bus = new Framebus({
@@ -97,7 +97,7 @@ This method is used in conjuction with `emit`, `on`, and `off` to
 restrict their results to the given origin. By default, an origin of
 `'*'` is used.
 
-``` javascript
+```javascript
 framebus
   .target({
     origin: "https://example.com",
@@ -136,7 +136,7 @@ Using this method assumes the browser context you are using supports
 Promises. If it does not, set a polyfill for the Framebus class with
 `setPromise`
 
-``` js
+```js
 // or however you want to polyfill the promise
 const PolyfilledPromise = require("promise-polyfill");
 
@@ -176,7 +176,7 @@ otherwise
 If framebus was instantiated with `targetFrames`, then the popup will be
 added to the `targetFrames` array.
 
-``` javascript
+```javascript
 var popup = window.open("https://example.com");
 
 framebus.include(popup);
@@ -192,7 +192,7 @@ framebus.emit("hello popup and friends!");
 Calls `off` on all listeners used for this bus instance and makes
 subsequent calls to all methods `noop`.
 
-``` javascript
+```javascript
 bus.on("event-name", handler);
 
 // event-name listener is torn down
@@ -244,12 +244,12 @@ occur as follows:
 
 1.  `http://emitter.example.com` publishes an event with a function as
     the event data
-    
-    ``` javascript
+
+    ```javascript
     var callback = function (data) {
       console.log("Got back %s as a reply!", data);
     };
-    
+
     framebus.emit("Marco!", callback, "http://listener.example.com");
     ```
 
@@ -264,8 +264,8 @@ occur as follows:
 4.  The subscriber on `http://listener.example.com` uses the local
     one-time-use callback function to send data back to the emitter's
     origin
-    
-    ``` javascript
+
+    ```javascript
     framebus
       .target("http://emitter.example.com")
       .on("Marco!", function (callback) {

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ type FramebusOptions = {
   origin?: string, // default: "*"
   channel?: string, // no default
   verifyDomain?: (url: string) => boolean, // no default
+  targetFrames?: Window[], // by default, all frames available to broadcast to
 };
 ```
 
@@ -56,6 +57,31 @@ var bus = new Framebus({
     url.indexOf("https://my-domain") === 0;
   },
 });
+```
+
+If a `targetFrames` array is passed, then framebus will only broadcast
+to those frames and listen for messages from those frames.
+
+```js
+var myIframe = document.getElementById("my-iframe");
+
+var bus = new Framebus({
+  targetFrames: [myIframe],
+});
+```
+
+To add additional frames to the `targetFrames` array in the future, use
+the `include` method. `targetFrames` must be set, even if it's an empty
+array, for this method to work.
+
+```js
+var myIframe = document.getElementById("my-iframe");
+
+var bus = new Framebus({
+  targetFrames: [],
+});
+
+bus.include(myIframe);
 ```
 
 ## API
@@ -144,6 +170,9 @@ otherwise
 
 **returns**: `true` if the popup was successfully included, `false`
 otherwise
+
+If framebus was instantiated with `targetFrames`, then the popup will be
+added to the `targetFrames` array.
 
 ```javascript
 var popup = window.open("https://example.com");

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var bus = new Framebus({
 });
 ```
 
-If a `targetFrames` array is passed, then framebus will only broadcast
+If a `targetFrames` array is passed, then framebus will only send messages
 to those frames and listen for messages from those frames. You can pass
 a reference to a `Window` (the return value of `window.open`) or an
 `HTMLFrameElement` (a DOM node representing an iframe).

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ var bus = new Framebus({
 });
 ```
 
-If a `targetFrames` array is passed, then framebus will only send messages
-to those frames and listen for messages from those frames. You can pass
-a reference to a `Window` (the return value of `window.open`) or an
-`HTMLFrameElement` (a DOM node representing an iframe).
+If a `targetFrames` array is passed, then framebus will only send
+messages to those frames and listen for messages from those frames. You
+can pass a reference to a `Window` (the return value of `window.open`)
+or an `HTMLFrameElement` (a DOM node representing an iframe).
 
 ```js
 var myIframe = document.getElementById("my-iframe");
@@ -73,8 +73,8 @@ var bus = new Framebus({
 ```
 
 To add additional frames to the `targetFrames` array in the future, use
-the `include` method. `targetFrames` must be set, even if it's an empty
-array, for this method to work.
+the `addTargetFrame` method. `targetFrames` must be set, even if it's an
+empty array, for this method to work.
 
 ```js
 var myIframe = document.getElementById("my-iframe");
@@ -83,7 +83,7 @@ var bus = new Framebus({
   targetFrames: [],
 });
 
-bus.include(myIframe);
+bus.addTargetFrame(myIframe);
 ```
 
 ## API
@@ -173,9 +173,6 @@ otherwise
 **returns**: `true` if the popup was successfully included, `false`
 otherwise
 
-If framebus was instantiated with `targetFrames`, then the popup will be
-added to the `targetFrames` array as well.
-
 ```javascript
 var popup = window.open("https://example.com");
 
@@ -186,6 +183,23 @@ framebus.emit("hello popup and friends!");
 | Argument | Type   | Description                                  |
 | -------- | ------ | -------------------------------------------- |
 | `popup`  | Window | The popup refrence returned by `window.open` |
+
+#### `addTargetFrame(frame): boolean`
+
+Used in conjunction with `targetFrames` configuration. If a
+`targetFrames` array is not passed on instantiation, this method will
+noop.
+
+```javascript
+var frame = document.getElementById("my-iframe");
+
+framebus.addTargetFrame(frame);
+framebus.emit("hello targetted iframe!");
+```
+
+| Argument | Type                        | Description                                  |
+| -------- | --------------------------- | -------------------------------------------- |
+| `frame`  | Window or HTMLIFrameElement | The iframe or popup to add to `targetFrames` |
 
 #### `teardown(): void`
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ otherwise
 otherwise
 
 If framebus was instantiated with `targetFrames`, then the popup will be
-added to the `targetFrames` array.
+added to the `targetFrames` array as well.
 
 ```javascript
 var popup = window.open("https://example.com");

--- a/spec/functional/public/html/frame1-inner.html
+++ b/spec/functional/public/html/frame1-inner.html
@@ -12,6 +12,12 @@
       var remoteOrigin = "http://<%= domain %>:<%= port2 %>";
       var button = document.getElementById("marco-button");
 
+      Framebus.target({
+        origin: "*"
+      }).on("special-message-to-parent", function (payload) {
+        app.printToDOM('FAIL: [inner frame 1] received "' + payload.message + '"');
+      });
+
       button.onclick = function () {
         Framebus.target({
           origin: remoteOrigin,

--- a/spec/functional/public/html/frame1-inner.html
+++ b/spec/functional/public/html/frame1-inner.html
@@ -13,9 +13,11 @@
       var button = document.getElementById("marco-button");
 
       Framebus.target({
-        origin: "*"
+        origin: "*",
       }).on("special-message-to-parent", function (payload) {
-        app.printToDOM('FAIL: [inner frame 1] received "' + payload.message + '"');
+        app.printToDOM(
+          'FAIL: [inner frame 1] received "' + payload.message + '"'
+        );
       });
 
       button.onclick = function () {

--- a/spec/functional/public/html/frame1.html
+++ b/spec/functional/public/html/frame1.html
@@ -12,6 +12,9 @@
       bus.on("Marco", function () {
         app.printToDOM('FAIL: [frame 1] received "Marco"');
       });
+      bus.on("special-message-to-parent", function (payload) {
+        app.printToDOM('FAIL: [frame 1] received "' + payload.message + '"');
+      });
     </script>
     <iframe src="/html/frame1-inner.html" name="frame1-inner"></iframe>
   </body>

--- a/spec/functional/public/html/frame2.html
+++ b/spec/functional/public/html/frame2.html
@@ -20,6 +20,9 @@
       bus.on("from-popup", function (data) {
         app.printToDOM('received "' + data.message + '" from popup');
       });
+      bus.on("special-message-to-parent", function (payload) {
+        app.printToDOM('FAIL: [frame 2] received "' + payload.message + '"');
+      });
     </script>
   </body>
 </html>

--- a/spec/functional/public/html/frame3.html
+++ b/spec/functional/public/html/frame3.html
@@ -14,7 +14,9 @@
     <br />
     <hr />
 
-    <button id="send-to-parent">Send a targetted message to only the parent frame</button>
+    <button id="send-to-parent">
+      Send a targetted message to only the parent frame
+    </button>
 
     <script src="/js/test-app.js"></script>
     <script>
@@ -26,13 +28,17 @@
         });
       });
 
-      document.querySelector("#send-to-parent").addEventListener("click", function () {
-        bus.target({
-          targetFrames: [window.parent]
-        }).emit("special-message-to-parent", {
-          message: "Special targetted message to only parent."
-        })
-      });
+      document
+        .querySelector("#send-to-parent")
+        .addEventListener("click", function () {
+          bus
+            .target({
+              targetFrames: [window.parent],
+            })
+            .emit("special-message-to-parent", {
+              message: "Special targetted message to only parent.",
+            });
+        });
 
       bus.on("Marco", function (data, reply) {
         var polo = document.getElementById("polo-text").value;

--- a/spec/functional/public/html/frame3.html
+++ b/spec/functional/public/html/frame3.html
@@ -11,6 +11,11 @@
     <input id="popup-message" />
     <button id="send">Send popup a message</button>
 
+    <br />
+    <hr />
+
+    <button id="send-to-parent">Send a targetted message to only the parent frame</button>
+
     <script src="/js/test-app.js"></script>
     <script>
       var bus = new Framebus();
@@ -21,12 +26,24 @@
         });
       });
 
+      document.querySelector("#send-to-parent").addEventListener("click", function () {
+        bus.target({
+          targetFrames: [window.parent]
+        }).emit("special-message-to-parent", {
+          message: "Special targetted message to only parent."
+        })
+      });
+
       bus.on("Marco", function (data, reply) {
         var polo = document.getElementById("polo-text").value;
         app.printToDOM(data.message);
         reply({
           message: polo,
         });
+      });
+
+      bus.on("special-message-to-parent", function (payload) {
+        app.printToDOM('FAIL: [frame 3] received "' + payload.message + '"');
       });
     </script>
   </body>

--- a/spec/functional/public/index.html
+++ b/spec/functional/public/index.html
@@ -31,11 +31,13 @@
       bus.on("Marco", function () {
         app.printToDOM('FAIL: [index] received "Marco"');
       });
-      bus.target({
-        targetFrames: [document.querySelector("[name='frame3']")]
-      }).on("special-message-to-parent", function (payload) {
-        app.printToDOM(payload.message);
-      });
+      bus
+        .target({
+          targetFrames: [document.querySelector("[name='frame3']")],
+        })
+        .on("special-message-to-parent", function (payload) {
+          app.printToDOM(payload.message);
+        });
 
       document.querySelector("#send-from-top").addEventListener(
         "click",

--- a/spec/functional/public/index.html
+++ b/spec/functional/public/index.html
@@ -31,6 +31,11 @@
       bus.on("Marco", function () {
         app.printToDOM('FAIL: [index] received "Marco"');
       });
+      bus.target({
+        targetFrames: [document.querySelector("[name='frame3']")]
+      }).on("special-message-to-parent", function (payload) {
+        app.printToDOM(payload.message);
+      });
 
       document.querySelector("#send-from-top").addEventListener(
         "click",

--- a/spec/functional/target-frames.js
+++ b/spec/functional/target-frames.js
@@ -1,0 +1,47 @@
+describe("targetFrames Events", () => {
+  beforeEach(() => {
+    browser.url("http://localhost:3099");
+  });
+
+  it("should only publish to targeted frames", () => {
+    browser.switchToFrame(2);
+
+    $("#send-to-parent").click();
+
+    browser.switchToParentFrame();
+
+    browser.waitUntil(
+      () => {
+        return $("p").getText() === "Special targetted message to only parent.";
+      },
+      {
+        timeout: 1000,
+        timeoutMsg: "expected p tag to have text",
+      }
+    );
+
+    const indexReceived = $$("p").length;
+
+    browser.switchToFrame(0);
+    const frame1Received = $$("p").length;
+
+    browser.switchToFrame(0);
+    const innerframe1Received = $$("p").length;
+
+    browser.switchToParentFrame();
+    browser.switchToParentFrame();
+
+    browser.switchToFrame(1);
+    const frame2Received = $$("p").length;
+    browser.switchToParentFrame();
+
+    browser.switchToFrame(2);
+    const frame3ReceivedQuestion = $$("p").length;
+
+    expect(indexReceived).toBe(1);
+    expect(innerframe1Received).toBe(0);
+    expect(frame1Received).toBe(0);
+    expect(frame2Received).toBe(0);
+    expect(frame3ReceivedQuestion).toBe(0);
+  });
+});

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -19,8 +19,7 @@ describe("broadcast", () => {
     expect(() => {
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
     }).not.toThrowError();
   });
@@ -30,8 +29,7 @@ describe("broadcast", () => {
 
     broadcast("payload", {
       origin: "*",
-      frames: [frame],
-      limitBroadcastToFramesArray: false,
+      frame: frame,
     });
 
     expect(frame.postMessage).toBeCalled();
@@ -43,8 +41,7 @@ describe("broadcast", () => {
 
     broadcast("payload", {
       origin: "*",
-      frames: [frame],
-      limitBroadcastToFramesArray: false,
+      frame: frame,
     });
 
     expect(frame.frames[0].postMessage).toBeCalled();
@@ -60,8 +57,7 @@ describe("broadcast", () => {
 
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
 
       expect(frame.opener.top.postMessage).toBeCalled();
@@ -80,8 +76,7 @@ describe("broadcast", () => {
 
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
 
       expect(frame.opener.top.postMessage).not.toBeCalled();
@@ -96,8 +91,7 @@ describe("broadcast", () => {
 
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
 
       // don't infinitely recurse
@@ -117,28 +111,11 @@ describe("broadcast", () => {
 
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
 
       // don't infinitely recurse
       done();
-    });
-
-    it("should not postMessage to window.top.opener if limitBroadcastToFramesArray is true", () => {
-      const frame = mkFrame();
-
-      frame.opener = mkFrame();
-      frame.top = frame;
-      frame.opener.top = frame.opener;
-
-      broadcast("payload", {
-        origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: true,
-      });
-
-      expect(frame.opener.top.postMessage).not.toBeCalled();
     });
 
     it("should postMessage to the window.opener's child frames", () => {
@@ -153,30 +130,10 @@ describe("broadcast", () => {
 
       broadcast("payload", {
         origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: false,
+        frame: frame,
       });
 
       expect(frame.opener.top.frames[0].postMessage).toBeCalled();
-    });
-
-    it("should not postMessage to the window.opener's child frames when limitBroadcastToFramesArray is true", () => {
-      const frame = mkFrame();
-      const openerFrame = mkFrame();
-
-      openerFrame.frames[0] = mkFrame();
-
-      frame.opener = openerFrame;
-      frame.opener.top = frame.opener;
-      frame.top = frame;
-
-      broadcast("payload", {
-        origin: "*",
-        frames: [frame],
-        limitBroadcastToFramesArray: true,
-      });
-
-      expect(frame.opener.top.frames[0].postMessage).not.toBeCalled();
     });
 
     it("should not throw if window.opener has access denied", () => {
@@ -193,8 +150,7 @@ describe("broadcast", () => {
       expect(() => {
         broadcast("payload", {
           origin: "*",
-          frames: [frame],
-          limitBroadcastToFramesArray: false,
+          frame: frame,
         });
       }).not.toThrowError("Access denied");
     });

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -17,14 +17,22 @@ describe("broadcast", () => {
     });
 
     expect(() => {
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
     }).not.toThrowError();
   });
 
   it("should postMessage to current frame", () => {
     const frame = mkFrame();
 
-    broadcast(frame, "payload", "*");
+    broadcast("payload", {
+      origin: "*",
+      frames: [frame],
+      limitBroadcastToFramesArray: false,
+    });
 
     expect(frame.postMessage).toBeCalled();
   });
@@ -33,7 +41,11 @@ describe("broadcast", () => {
     const frame = mkFrame();
     frame.frames[0] = mkFrame();
 
-    broadcast(frame, "payload", "*");
+    broadcast("payload", {
+      origin: "*",
+      frames: [frame],
+      limitBroadcastToFramesArray: false,
+    });
 
     expect(frame.frames[0].postMessage).toBeCalled();
   });
@@ -46,7 +58,11 @@ describe("broadcast", () => {
       frame.top = frame;
       frame.opener.top = frame.opener;
 
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
 
       expect(frame.opener.top.postMessage).toBeCalled();
     });
@@ -62,7 +78,11 @@ describe("broadcast", () => {
       frame.opener.top = frame.opener;
       frame.top = frame;
 
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
 
       expect(frame.opener.top.postMessage).not.toBeCalled();
     });
@@ -74,7 +94,11 @@ describe("broadcast", () => {
       frame.opener = frame;
       frame.top = frame;
 
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
 
       // don't infinitely recurse
       done();
@@ -91,7 +115,11 @@ describe("broadcast", () => {
       frame.frames[0] = child;
       frame.top = frame;
 
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
 
       // don't infinitely recurse
       done();
@@ -107,7 +135,11 @@ describe("broadcast", () => {
       frame.opener.top = frame.opener;
       frame.top = frame;
 
-      broadcast(frame, "payload", "*");
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: false,
+      });
 
       expect(frame.opener.top.frames[0].postMessage).toBeCalled();
     });
@@ -124,7 +156,11 @@ describe("broadcast", () => {
       });
 
       expect(() => {
-        broadcast(frame, "payload", "*");
+        broadcast("payload", {
+          origin: "*",
+          frames: [frame],
+          limitBroadcastToFramesArray: false,
+        });
       }).not.toThrowError("Access denied");
     });
   });

--- a/spec/unit/broadcast.spec.ts
+++ b/spec/unit/broadcast.spec.ts
@@ -125,6 +125,22 @@ describe("broadcast", () => {
       done();
     });
 
+    it("should not postMessage to window.top.opener if limitBroadcastToFramesArray is true", () => {
+      const frame = mkFrame();
+
+      frame.opener = mkFrame();
+      frame.top = frame;
+      frame.opener.top = frame.opener;
+
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: true,
+      });
+
+      expect(frame.opener.top.postMessage).not.toBeCalled();
+    });
+
     it("should postMessage to the window.opener's child frames", () => {
       const frame = mkFrame();
       const openerFrame = mkFrame();
@@ -142,6 +158,25 @@ describe("broadcast", () => {
       });
 
       expect(frame.opener.top.frames[0].postMessage).toBeCalled();
+    });
+
+    it("should not postMessage to the window.opener's child frames when limitBroadcastToFramesArray is true", () => {
+      const frame = mkFrame();
+      const openerFrame = mkFrame();
+
+      openerFrame.frames[0] = mkFrame();
+
+      frame.opener = openerFrame;
+      frame.opener.top = frame.opener;
+      frame.top = frame;
+
+      broadcast("payload", {
+        origin: "*",
+        frames: [frame],
+        limitBroadcastToFramesArray: true,
+      });
+
+      expect(frame.opener.top.frames[0].postMessage).not.toBeCalled();
     });
 
     it("should not throw if window.opener has access denied", () => {

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -157,11 +157,11 @@ describe("Framebus", () => {
       });
 
       expect(broadcast).toBeCalledTimes(1);
-      expect(broadcast).toBeCalledWith(
-        window.top,
-        expect.stringContaining('"foo":"bar"'),
-        "*"
-      );
+      expect(broadcast).toBeCalledWith(expect.stringContaining('"foo":"bar"'), {
+        origin: "*",
+        frames: [window.top],
+        limitBroadcastToFramesArray: false,
+      });
     });
 
     it("does not broadcast if torn down", () => {
@@ -182,11 +182,11 @@ describe("Framebus", () => {
       });
 
       expect(broadcast).toBeCalledTimes(1);
-      expect(broadcast).toBeCalledWith(
-        window.top,
-        expect.stringContaining('"foo":"bar"'),
-        "foo"
-      );
+      expect(broadcast).toBeCalledWith(expect.stringContaining('"foo":"bar"'), {
+        origin: "foo",
+        frames: [window.top],
+        limitBroadcastToFramesArray: false,
+      });
     });
 
     it("broadcasts to specified channel", () => {
@@ -201,9 +201,12 @@ describe("Framebus", () => {
 
       expect(broadcast).toBeCalledTimes(1);
       expect(broadcast).toBeCalledWith(
-        window.top,
         expect.stringContaining('"unique-channel:event-name"'),
-        "*"
+        {
+          origin: "*",
+          frames: [window.top],
+          limitBroadcastToFramesArray: false,
+        }
       );
     });
 
@@ -214,9 +217,12 @@ describe("Framebus", () => {
 
       expect(broadcast).toBeCalledTimes(1);
       expect(broadcast).toBeCalledWith(
-        window.top,
         expect.stringContaining('"event-name"'),
-        "*"
+        {
+          origin: "*",
+          frames: [window.top],
+          limitBroadcastToFramesArray: false,
+        }
       );
     });
 
@@ -224,11 +230,11 @@ describe("Framebus", () => {
       bus.emit("event-name", { foo: "bar" });
 
       expect(broadcast).toBeCalledTimes(1);
-      expect(broadcast).toBeCalledWith(
-        window.top,
-        expect.stringContaining('"foo":"bar"'),
-        "*"
-      );
+      expect(broadcast).toBeCalledWith(expect.stringContaining('"foo":"bar"'), {
+        origin: "*",
+        frames: [window.top],
+        limitBroadcastToFramesArray: false,
+      });
     });
 
     it("does not require data or a callback", () => {
@@ -236,9 +242,12 @@ describe("Framebus", () => {
 
       expect(broadcast).toBeCalledTimes(1);
       expect(broadcast).toBeCalledWith(
-        window.top,
         expect.stringContaining('"event-name"'),
-        "*"
+        {
+          origin: "*",
+          frames: [window.top],
+          limitBroadcastToFramesArray: false,
+        }
       );
     });
   });

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -113,8 +113,10 @@ describe("Framebus", () => {
         })
       ).toBe(true);
     });
+  });
 
-    it("includes the frame in the targetFrames property, when configured", () => {
+  describe("addTargetFrame", () => {
+    it("includes the window in the targetFrames property, when configured", () => {
       const fakeWindow = {};
       const frame = {
         // @ts-ignore
@@ -132,7 +134,25 @@ describe("Framebus", () => {
       expect(targets.length).toBe(0);
 
       // @ts-ignore
-      busWithTargetFrames.include(frame);
+      busWithTargetFrames.addTargetFrame(frame);
+
+      expect(targets.length).toBe(1);
+      expect(targets[0]).toBe(frame);
+    });
+
+    it("includes the iframe in the targetFrames property, when configured", () => {
+      const frame = document.createElement("iframe");
+      const targetFrames = [] as Window[];
+      const busWithTargetFrames = new Framebus({
+        targetFrames,
+      });
+
+      const targets = busWithTargetFrames.targetFrames as Window[];
+
+      expect(targets.length).toBe(0);
+
+      // @ts-ignore
+      busWithTargetFrames.addTargetFrame(frame);
 
       expect(targets.length).toBe(1);
       expect(targets[0]).toBe(frame);

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -32,26 +32,6 @@ describe("Framebus", () => {
     });
   });
 
-  describe("targetFrames", () => {
-    it("normalizes targetFrames to Window objects", () => {
-      const iframe = document.createElement("iframe");
-      const targetFrames = [iframe, window] as Array<
-        HTMLIFrameElement | Window
-      >;
-
-      const busWithTargetFrames = new Framebus({
-        targetFrames,
-      });
-
-      const targets = busWithTargetFrames.targetFrames as Window[];
-
-      expect(targets.length).toBe(2);
-      expect(targets[0]).toBe(iframe.contentWindow);
-      // checking the window equality will result in a circular json error
-      expect(targets[1]).toBeTruthy();
-    });
-  });
-
   describe("target", () => {
     it("returns a new Framebus isntance", () => {
       const instance = Framebus.target();

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -111,6 +111,28 @@ describe("Framebus", () => {
         })
       ).toBe(true);
     });
+
+    it("includes the frame in the targetFrames property, when configured", () => {
+      const fakeWindow = {};
+      const frame = {
+        // @ts-ignore
+        Window: fakeWindow,
+        // @ts-ignore
+        constructor: fakeWindow,
+      };
+      const targetFrames = [] as Window[];
+      const busWithTargetFrames = bus.target({
+        targetFrames,
+      });
+
+      expect(targetFrames.length).toBe(0);
+
+      // @ts-ignore
+      busWithTargetFrames.include(frame);
+
+      expect(targetFrames.length).toBe(1);
+      expect(targetFrames[0]).toBe(frame);
+    });
   });
 
   describe("emit", () => {

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -32,6 +32,26 @@ describe("Framebus", () => {
     });
   });
 
+  describe("targetFrames", () => {
+    it("normalizes targetFrames to Window objects", () => {
+      const iframe = document.createElement("iframe");
+      const targetFrames = [iframe, window] as Array<
+        HTMLIFrameElement | Window
+      >;
+
+      const busWithTargetFrames = new Framebus({
+        targetFrames,
+      });
+
+      const targets = busWithTargetFrames.targetFrames as Window[];
+
+      expect(targets.length).toBe(2);
+      expect(targets[0]).toBe(iframe.contentWindow);
+      // checking the window equality will result in a circular json error
+      expect(targets[1]).toBeTruthy();
+    });
+  });
+
   describe("target", () => {
     it("returns a new Framebus isntance", () => {
       const instance = Framebus.target();
@@ -121,17 +141,19 @@ describe("Framebus", () => {
         constructor: fakeWindow,
       };
       const targetFrames = [] as Window[];
-      const busWithTargetFrames = bus.target({
+      const busWithTargetFrames = new Framebus({
         targetFrames,
       });
 
-      expect(targetFrames.length).toBe(0);
+      const targets = busWithTargetFrames.targetFrames as Window[];
+
+      expect(targets.length).toBe(0);
 
       // @ts-ignore
       busWithTargetFrames.include(frame);
 
-      expect(targetFrames.length).toBe(1);
-      expect(targetFrames[0]).toBe(frame);
+      expect(targets.length).toBe(1);
+      expect(targets[0]).toBe(frame);
     });
   });
 

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -210,6 +210,29 @@ describe("Framebus", () => {
       );
     });
 
+    it("broadcasts to targetFrames", () => {
+      const iframe1 = document.createElement("iframe");
+      const iframe2 = document.createElement("iframe");
+      document.body.appendChild(iframe1);
+      document.body.appendChild(iframe2);
+
+      bus = new Framebus({
+        targetFrames: [iframe1, iframe2],
+      });
+
+      const data = { foo: "bar" };
+      bus.emit("event-name", data, () => {
+        // noop
+      });
+
+      expect(broadcast).toBeCalledTimes(1);
+      expect(broadcast).toBeCalledWith(expect.stringContaining('"foo":"bar"'), {
+        origin: "*",
+        frames: [iframe1.contentWindow, iframe2.contentWindow],
+        limitBroadcastToFramesArray: true,
+      });
+    });
+
     it("does not require data", () => {
       bus.emit("event-name", () => {
         // noop

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -227,13 +227,13 @@ describe("Framebus", () => {
 
       expect(sendMessage).toHaveBeenNthCalledWith(
         1,
-        iframe1,
+        iframe1.contentWindow,
         expect.stringContaining('"foo":"bar"'),
         "*"
       );
       expect(sendMessage).toHaveBeenNthCalledWith(
         2,
-        iframe2,
+        iframe2.contentWindow,
         expect.stringContaining('"foo":"bar"'),
         "*"
       );

--- a/spec/unit/framebus.spec.ts
+++ b/spec/unit/framebus.spec.ts
@@ -163,7 +163,7 @@ describe("Framebus", () => {
         origin: "*",
         frame: window.top,
       });
-      expect(sendMessage).not.toBeCalled()
+      expect(sendMessage).not.toBeCalled();
     });
 
     it("does not broadcast if torn down", () => {

--- a/spec/unit/send-message.spec.ts
+++ b/spec/unit/send-message.spec.ts
@@ -1,0 +1,29 @@
+import { sendMessage } from "../../src/lib/send-message";
+
+function mkFrame() {
+  return {
+    ...(window as Window),
+    postMessage: jest.fn(),
+    closed: false,
+  };
+}
+
+describe("sendMessage()", () => {
+  const payload = JSON.stringify({ something: true });
+  const origin = "https://the-internet.com/";
+  const frame = mkFrame();
+
+  it("sends a message", () => {
+    sendMessage(frame, payload, origin);
+    expect(frame.postMessage).toBeCalledWith(payload, origin);
+  });
+
+  it("swallows error if postMessage throws", () => {
+    const failFrame = mkFrame();
+    failFrame.postMessage.mockImplementation(() => {
+      throw new Error();
+    });
+    sendMessage(failFrame, payload, origin);
+    expect(failFrame.postMessage).toBeCalledTimes(1);
+  });
+});

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -21,7 +21,7 @@ type FramebusOptions = {
   channel?: string;
   origin?: string;
   verifyDomain?: VerifyDomainMethod;
-  targetFrames?: Window[];
+  targetFrames?: Array<HTMLIFrameElement | Window>;
 };
 
 const DefaultPromise = (typeof window !== "undefined" &&
@@ -30,17 +30,28 @@ const DefaultPromise = (typeof window !== "undefined" &&
 export class Framebus {
   origin: string;
   channel: string;
+  targetFrames?: Window[];
 
   private verifyDomain?: VerifyDomainMethod;
   private isDestroyed: boolean;
   private listeners: Listener[];
-  private targetFrames?: Window[];
 
   constructor(options: FramebusOptions = {}) {
     this.origin = options.origin || "*";
     this.channel = options.channel || "";
     this.verifyDomain = options.verifyDomain;
-    this.targetFrames = options.targetFrames;
+
+    if (options.targetFrames) {
+      this.targetFrames = options.targetFrames.map((iframeOrWindow) => {
+        // if it's an iframe, we need a reference to the Window proxy object
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentWindow
+        if (iframeOrWindow instanceof HTMLIFrameElement) {
+          return iframeOrWindow.contentWindow;
+        }
+
+        return iframeOrWindow;
+      }) as Window[];
+    }
 
     this.isDestroyed = false;
     this.listeners = [];

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -21,6 +21,7 @@ type FramebusOptions = {
   channel?: string;
   origin?: string;
   verifyDomain?: VerifyDomainMethod;
+  targetFrames?: Window[];
 };
 
 const DefaultPromise = (typeof window !== "undefined" &&
@@ -33,11 +34,13 @@ export class Framebus {
   private verifyDomain?: VerifyDomainMethod;
   private isDestroyed: boolean;
   private listeners: Listener[];
+  private targetFrames?: Window[];
 
   constructor(options: FramebusOptions = {}) {
     this.origin = options.origin || "*";
     this.channel = options.channel || "";
     this.verifyDomain = options.verifyDomain;
+    this.targetFrames = options.targetFrames;
 
     this.isDestroyed = false;
     this.listeners = [];
@@ -65,6 +68,10 @@ export class Framebus {
     }
 
     childWindows.push(childWindow);
+
+    if (this.targetFrames) {
+      this.targetFrames.push(childWindow);
+    }
 
     return true;
   }

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -273,7 +273,7 @@ export class Framebus {
   }
 
   private targetFramesAsWindows(): Window[] {
-    if (!this.targetFrames) {
+    if (!this.limitBroadcastToFramesArray) {
       return [];
     }
 

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -2,6 +2,7 @@ import { isntString } from "./lib/is-not-string";
 import { subscriptionArgsInvalid } from "./lib/subscription-args-invalid";
 import { broadcast } from "./lib/broadcast";
 import { packagePayload } from "./lib/package-payload";
+import { sendMessage } from "./lib/send-message";
 
 import { childWindows, subscribers } from "./lib/constants";
 
@@ -124,12 +125,16 @@ export class Framebus {
     if (!payload) {
       return false;
     }
-
-    broadcast(payload, {
-      origin,
-      frames: this.targetFramesAsWindows(),
-      limitBroadcastToFramesArray: this.limitBroadcastToFramesArray,
-    });
+    if (this.limitBroadcastToFramesArray) {
+      this.targetFrames.forEach((frame) => {
+        sendMessage(frame as Window, payload, origin);
+      });
+    } else {
+      broadcast(payload, {
+        origin,
+        frame: window.top || window.self,
+      });
+    }
 
     return true;
   }

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -78,10 +78,19 @@ export class Framebus {
     return new Framebus(options);
   }
 
+  addTargetFrame(frame: Window | HTMLIFrameElement): void {
+    if (!this.limitBroadcastToFramesArray) {
+      return;
+    }
+
+    this.targetFrames.push(frame);
+  }
+
   include(childWindow: Window): boolean {
     if (childWindow == null) {
       return false;
     }
+
     if (childWindow.Window == null) {
       return false;
     }
@@ -90,10 +99,6 @@ export class Framebus {
     }
 
     childWindows.push(childWindow);
-
-    if (this.limitBroadcastToFramesArray) {
-      this.targetFrames.push(childWindow);
-    }
 
     return true;
   }

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -57,7 +57,9 @@ export class Framebus {
     this.isDestroyed = false;
     this.listeners = [];
 
-    this.hasAdditionalChecksForOnListeners = Boolean(this.verifyDomain);
+    this.hasAdditionalChecksForOnListeners = Boolean(
+      this.verifyDomain || this.targetFrames
+    );
   }
 
   static Promise = DefaultPromise;
@@ -168,6 +170,11 @@ export class Framebus {
           return;
         }
 
+        // @ts-ignore
+        if (!self.hasMatchingTargetFrame(this && this.source)) {
+          return;
+        }
+
         originalHandler(...args);
       };
       /* eslint-enable no-invalid-this, @typescript-eslint/ban-ts-comment */
@@ -249,6 +256,19 @@ export class Framebus {
     }
 
     return this.checkOrigin(origin);
+  }
+
+  private hasMatchingTargetFrame(source: Window): boolean {
+    if (!this.targetFrames) {
+      // always pass this check if no targetFrames option was set
+      return true;
+    }
+
+    const matchingFrame = this.targetFrames.find((frame) => {
+      return frame === source;
+    });
+
+    return Boolean(matchingFrame);
   }
 
   private checkOrigin(postMessageOrigin: string) {

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -21,7 +21,7 @@ type VerifyDomainMethod = (domain: string) => boolean;
 // this is a mixed type so that users can add iframes to the array
 // before they have been added to the DOM (in which case, they
 // would not have a contentWindow yet). When accessing these
-// windows in Framebus, the targetFramesAsWindows private 
+// windows in Framebus, the targetFramesAsWindows private
 // method should be used
 type IFrameOrWindowList = Array<HTMLIFrameElement | Window>;
 type FramebusOptions = {

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -116,7 +116,11 @@ export class Framebus {
       return false;
     }
 
-    broadcast(window.top || window.self, payload, origin);
+    broadcast(payload, {
+      origin,
+      frames: [window.top || window.self],
+      limitBroadcastToFramesArray: false,
+    });
 
     return true;
   }

--- a/src/lib/broadcast-to-child-windows.ts
+++ b/src/lib/broadcast-to-child-windows.ts
@@ -12,7 +12,11 @@ export function broadcastToChildWindows(
     if (childWindow.closed) {
       childWindows.splice(i, 1);
     } else if (source !== childWindow) {
-      broadcast(childWindow.top as Window, payload, origin);
+      broadcast(payload, {
+        origin,
+        frames: [childWindow.top as Window],
+        limitBroadcastToFramesArray: false,
+      });
     }
   }
 }

--- a/src/lib/broadcast-to-child-windows.ts
+++ b/src/lib/broadcast-to-child-windows.ts
@@ -14,8 +14,7 @@ export function broadcastToChildWindows(
     } else if (source !== childWindow) {
       broadcast(payload, {
         origin,
-        frames: [childWindow.top as Window],
-        limitBroadcastToFramesArray: false,
+        frame: childWindow.top as Window,
       });
     }
   }

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -2,50 +2,41 @@ import { hasOpener } from "./has-opener";
 
 type BroadcastOptions = {
   origin: string;
-  frames: Window[];
-  limitBroadcastToFramesArray: boolean;
+  frame: Window;
 };
 
 export function broadcast(payload: string, options: BroadcastOptions): void {
   let i = 0;
   let frameToBroadcastTo;
 
-  const { origin, frames, limitBroadcastToFramesArray } = options;
+  const { origin, frame } = options;
 
-  frames.forEach((frame) => {
-    try {
-      frame.postMessage(payload, origin);
+  try {
+    frame.postMessage(payload, origin);
 
-      if (limitBroadcastToFramesArray) {
-        return;
-      }
-
-      if (hasOpener(frame) && frame.opener.top !== window.top) {
-        broadcast(payload, {
-          origin,
-          frames: [frame.opener.top],
-          limitBroadcastToFramesArray,
-        });
-      }
-
-      // previously, our max value was frame.frames.length
-      // but frames.length inherits from window.length
-      // which can be overwritten if a developer does
-      // `var length = value;` outside of a function
-      // scope, it'll prevent us from looping through
-      // all the frames. With this, we loop through
-      // until there are no longer any frames
-      // eslint-disable-next-line no-cond-assign
-      while ((frameToBroadcastTo = frame.frames[i])) {
-        broadcast(payload, {
-          origin,
-          frames: [frameToBroadcastTo],
-          limitBroadcastToFramesArray,
-        });
-        i++;
-      }
-    } catch (_) {
-      /* ignored */
+    if (hasOpener(frame) && frame.opener.top !== window.top) {
+      broadcast(payload, {
+        origin,
+        frame: frame.opener.top,
+      });
     }
-  });
+
+    // previously, our max value was frame.frames.length
+    // but frames.length inherits from window.length
+    // which can be overwritten if a developer does
+    // `var length = value;` outside of a function
+    // scope, it'll prevent us from looping through
+    // all the frames. With this, we loop through
+    // until there are no longer any frames
+    // eslint-disable-next-line no-cond-assign
+    while ((frameToBroadcastTo = frame.frames[i])) {
+      broadcast(payload, {
+        origin,
+        frame: frameToBroadcastTo,
+      });
+      i++;
+    }
+  } catch (_) {
+    /* ignored */
+  }
 }

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -10,7 +10,7 @@ export function broadcast(payload: string, options: BroadcastOptions): void {
   let i = 0;
   let frameToBroadcastTo;
 
-  const { frames, limitBroadcastToFramesArray } = options;
+  const { origin, frames, limitBroadcastToFramesArray } = options;
 
   const frame = frames[0];
   // frames.forEach((frame) => {

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -16,9 +16,9 @@ export function broadcast(payload: string, options: BroadcastOptions): void {
     try {
       frame.postMessage(payload, origin);
 
-      // if (limitBroadcastToFramesArray) {
-      //   return;
-      // }
+      if (limitBroadcastToFramesArray) {
+        return;
+      }
 
       if (hasOpener(frame) && frame.opener.top !== window.top) {
         broadcast(payload, {

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -12,41 +12,40 @@ export function broadcast(payload: string, options: BroadcastOptions): void {
 
   const { origin, frames, limitBroadcastToFramesArray } = options;
 
-  const frame = frames[0];
-  // frames.forEach((frame) => {
-  try {
-    frame.postMessage(payload, origin);
+  frames.forEach((frame) => {
+    try {
+      frame.postMessage(payload, origin);
 
-    // if (limitBroadcastToFramesArray) {
-    //   return;
-    // }
+      // if (limitBroadcastToFramesArray) {
+      //   return;
+      // }
 
-    if (hasOpener(frame) && frame.opener.top !== window.top) {
-      broadcast(payload, {
-        origin,
-        frames: [frame.opener.top],
-        limitBroadcastToFramesArray,
-      });
+      if (hasOpener(frame) && frame.opener.top !== window.top) {
+        broadcast(payload, {
+          origin,
+          frames: [frame.opener.top],
+          limitBroadcastToFramesArray,
+        });
+      }
+
+      // previously, our max value was frame.frames.length
+      // but frames.length inherits from window.length
+      // which can be overwritten if a developer does
+      // `var length = value;` outside of a function
+      // scope, it'll prevent us from looping through
+      // all the frames. With this, we loop through
+      // until there are no longer any frames
+      // eslint-disable-next-line no-cond-assign
+      while ((frameToBroadcastTo = frame.frames[i])) {
+        broadcast(payload, {
+          origin,
+          frames: [frameToBroadcastTo],
+          limitBroadcastToFramesArray,
+        });
+        i++;
+      }
+    } catch (_) {
+      /* ignored */
     }
-
-    // previously, our max value was frame.frames.length
-    // but frames.length inherits from window.length
-    // which can be overwritten if a developer does
-    // `var length = value;` outside of a function
-    // scope, it'll prevent us from looping through
-    // all the frames. With this, we loop through
-    // until there are no longer any frames
-    // eslint-disable-next-line no-cond-assign
-    while ((frameToBroadcastTo = frame.frames[i])) {
-      broadcast(payload, {
-        origin,
-        frames: [frameToBroadcastTo],
-        limitBroadcastToFramesArray,
-      });
-      i++;
-    }
-  } catch (_) {
-    /* ignored */
-  }
-  // });
+  });
 }

--- a/src/lib/send-message.ts
+++ b/src/lib/send-message.ts
@@ -1,0 +1,14 @@
+/**
+ * A basic function for wrapping the sending of postMessages to frames.
+ */
+export function sendMessage(
+  frame: Window,
+  payload: string,
+  origin: string
+): void {
+  try {
+    frame.postMessage(payload, origin);
+  } catch (error) {
+    /* ignored */
+  }
+}

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -23,7 +23,11 @@ exports.config = {
   // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
   // directory is where your package.json resides, so `wdio` will be called from there.
   //
-  specs: ["spec/functional/popup-spec.js", "spec/functional/reply-spec.js"],
+  specs: [
+    "spec/functional/popup-spec.js",
+    "spec/functional/reply-spec.js",
+    "spec/functional/target-frames.js",
+  ],
   // Patterns to exclude.
   exclude: [
     // 'path/to/excluded/files'


### PR DESCRIPTION
This PR allows us to more effectively target what frames to communicate with (and avoid noisy console.errors about mismatched origins)

Also allows users to specify frames in the shadow DOM for communication.

closes #51 