### PR TITLE
chore: skipLibCheck in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "outDir": "./dist",
     "module": "commonjs",
     "target": "es5",


### PR DESCRIPTION
`npm run build` is currently throwing errors because of issues inside the `node_modules` folder.