### PR TITLE
fix: issue where off does not correctly unsubscribe when targetFrames provided

### DIFF
--- a/spec/unit/off.spec.ts
+++ b/spec/unit/off.spec.ts
@@ -77,4 +77,20 @@ describe("off", () => {
 
     expect(actual).toBe(false);
   });
+
+  it("correctly removes the handler when there are additional checks", () => {
+    const event = "the event";
+    const origin = "https://example.com";
+    const originalHandler = jest.fn();
+
+    const framebus = Framebus.target({
+      origin,
+      targetFrames: [window],
+    });
+    const added = framebus.on(event, originalHandler);
+    const removed = framebus.off(event, originalHandler);
+
+    expect(added).toBe(true);
+    expect(removed).toBe(true);
+  });
 });

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -6,6 +6,7 @@ import {
   sendMessage,
   childWindows,
   subscribers,
+  originalToInternalHandlerMap,
 } from "./lib";
 
 import type {
@@ -202,6 +203,8 @@ export class Framebus {
         originalHandler(...args);
       };
       /* eslint-enable no-invalid-this, @typescript-eslint/ban-ts-comment */
+
+      originalToInternalHandlerMap.set(originalHandler, handler);
     }
 
     this.listeners.push({
@@ -247,9 +250,17 @@ export class Framebus {
       return false;
     }
 
+    const internalHandler = originalToInternalHandlerMap.get(handler);
     for (let i = 0; i < subscriberList.length; i++) {
-      if (subscriberList[i] === handler) {
+      if (
+        subscriberList[i] === handler ||
+        subscriberList[i] === internalHandler
+      ) {
         subscriberList.splice(i, 1);
+
+        if (internalHandler) {
+          originalToInternalHandlerMap.delete(handler);
+        }
 
         return true;
       }

--- a/src/framebus.ts
+++ b/src/framebus.ts
@@ -6,7 +6,6 @@ import {
   sendMessage,
   childWindows,
   subscribers,
-  originalToInternalHandlerMap,
 } from "./lib";
 
 import type {
@@ -203,8 +202,6 @@ export class Framebus {
         originalHandler(...args);
       };
       /* eslint-enable no-invalid-this, @typescript-eslint/ban-ts-comment */
-
-      originalToInternalHandlerMap.set(originalHandler, handler);
     }
 
     this.listeners.push({
@@ -227,7 +224,7 @@ export class Framebus {
       return false;
     }
 
-    if (this.verifyDomain) {
+    if (this.hasAdditionalChecksForOnListeners) {
       for (let i = 0; i < this.listeners.length; i++) {
         const listener = this.listeners[i];
 
@@ -250,17 +247,9 @@ export class Framebus {
       return false;
     }
 
-    const internalHandler = originalToInternalHandlerMap.get(handler);
     for (let i = 0; i < subscriberList.length; i++) {
-      if (
-        subscriberList[i] === handler ||
-        subscriberList[i] === internalHandler
-      ) {
+      if (subscriberList[i] === handler) {
         subscriberList.splice(i, 1);
-
-        if (internalHandler) {
-          originalToInternalHandlerMap.delete(handler);
-        }
 
         return true;
       }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,5 @@
-import type { FramebusOnHandler, FramebusSubscriber } from "./";
+import type { FramebusSubscriber } from "./";
 
 export const prefix = "/*framebus*/";
 export const childWindows: Window[] = [];
 export const subscribers: FramebusSubscriber = {};
-export const originalToInternalHandlerMap: Map<
-  FramebusOnHandler,
-  FramebusOnHandler
-> = new Map();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,9 @@
-import type { FramebusSubscriber } from "./";
+import type { FramebusOnHandler, FramebusSubscriber } from "./";
 
 export const prefix = "/*framebus*/";
 export const childWindows: Window[] = [];
 export const subscribers: FramebusSubscriber = {};
+export const originalToInternalHandlerMap: Map<
+  FramebusOnHandler,
+  FramebusOnHandler
+> = new Map();


### PR DESCRIPTION
## Summary
This PR fixes a bug which makes it impossible to unsubscribe a handler whenever the `targetFrames` option is passed to the initialization of a `Framebus`.

### What Was Wrong
When the `targetFrames` option is included, an internal variable is set which indicates there are additional checks for on listeners, as per this code:

```
    this.limitBroadcastToFramesArray = Boolean(options.targetFrames);
    ...
    this.hasAdditionalChecksForOnListeners = Boolean(
      this.verifyDomain || this.limitBroadcastToFramesArray
    );
```

Whenever this variable is set to `true` like this, the handler function passed when calling `on` for a `Framebus` is overwritten to a _new_ function created on-the-fly which applies these additional checks and then calls the original function, as per this code:

```
    let handler = originalHandler;
    ...
    if (this.hasAdditionalChecksForOnListeners) {
      handler = function (...args) {
        // additional checks are done here...

        originalHandler(...args);
      };
    }
```

and then this _new_ handler is added to the list of subscriptions, as per this code:
```
    subscribers[origin] = subscribers[origin] || {};
    subscribers[origin][eventName] = subscribers[origin][eventName] || [];
    subscribers[origin][eventName].push(handler as FramebusSubscribeHandler);
```

This ultimately results in a bug because when calling `off` with a handler function, we're comparing the _original_ handler to the _new_ handler created as a one-off by reference. This referential equality check fails, so `off` determines there is nothing to unsubscribe.

This causes issues if you're using the `Framebus` in React, for example, and you need to setup subscriptions inside `useEffect` hooks that can run more than once and thus require cleanup so as to not create multiple subscriptions (this is how I discovered this bug).

## Testing
I tested this version of the code in my own project and it resolves the issue. All of the existing unit tests are continuing to pass.