### PR TITLE
Add publishing gh actions, update existing actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Summary
+
+<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
+
+### Checklist
+
+- [ ] Added a changelog entry
+
+### Authors
+
+> List GitHub usernames for everyone who contributed to this pull request.
+
+-
+
+### Reviewers
+
+@braintree/team-sdk-js 

--- a/.github/workflows/ci-functional-tests.yml
+++ b/.github/workflows/ci-functional-tests.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-      - uses: actions/setup-node@v4
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
       - run: npm install

--- a/.github/workflows/ci-functional-tests.yml
+++ b/.github/workflows/ci-functional-tests.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version-file: .nvmrc
       - run: npm install
       - run: sudo apt-get install xvfb
       # there's a weird typescript incompatibility with jest types and mocha types

--- a/.github/workflows/ci-functional-tests.yml
+++ b/.github/workflows/ci-functional-tests.yml
@@ -1,6 +1,12 @@
 name: "Functional Tests"
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches:
+        - '*'
 
 jobs:
   build:

--- a/.github/workflows/ci-functional-tests.yml
+++ b/.github/workflows/ci-functional-tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version-file: .nvmrc
       - run: npm install

--- a/.github/workflows/ci-functional-tests.yml
+++ b/.github/workflows/ci-functional-tests.yml
@@ -2,8 +2,9 @@ name: "Functional Tests"
 
 on:
   push:
+    branches:
+      - 'main'
   workflow_dispatch:
-  workflow_call:
   pull_request:
     branches:
         - '*'

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version-file: .nvmrc
       - run: npm install
       - run: npm run lint
       - run: npm run test:unit

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-      - uses: actions/setup-node@v4
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
       - run: npm install

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -2,6 +2,8 @@ name: "Unit Tests"
 
 on:
   push:
+    branches:
+      - 'main'
   workflow_dispatch:
   workflow_call:
   pull_request:

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -1,6 +1,12 @@
 name: "Unit Tests"
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches:
+        - '*'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+# This workflow will run tests using node, bump the npm version, deploy to npm, and create a release with notes 
+
+name: Publish to npm 
+run-name: Deploy ${{ github.repository }} to npmjs by @${{ github.actor }}
+on:
+    workflow_dispatch:
+      inputs:
+        version_type:
+          description: "Version bump type (major, minor, patch)"
+          required: true
+          type: choice
+          options:
+            - major
+            - minor
+            - patch
+
+env:
+    NPM_REGISTRY: https://registry.npmjs.org/
+
+concurrency: # prevent concurrent releases
+  group: npm-publish 
+  cancel-in-progress: true
+
+jobs:
+  ci-unit-tests: 
+    uses: ./.github/workflows/ci-unit-tests.yml
+  bump-version:
+    needs: ci-unit-tests
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      version_type: ${{ inputs.version_type }}
+  publish-npm:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: ${{ env.NPM_REGISTRY }} 
+      - run: npm ci
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
+  publish-release:
+    needs: publish-npm
+    uses: ./.github/workflows/release-notes.yml 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,43 @@
+# This workflow will create a release for the most recent deploy 
+
+name: Create release 
+run-name: Running github release 
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code  
+        uses: actions/checkout@v4
+
+      - name: Get version
+        run: |
+          git pull
+          latest_version=$(awk '/^## / { if (p) exit; p=1 } p' CHANGELOG.md | grep '##' | sed 's/## //')
+          if $(echo $latest_version | grep -q "(");then
+            latest_version=$(echo $latest_version | sed 's/\ (.*$//')
+          fi
+          echo "latest_version=$(echo $latest_version)" >> $GITHUB_ENV
+
+      - name: Get details
+        run: |
+          {
+            echo 'release_details<<EOF'
+            awk '/^## / { if (p) exit; p=1 } p' CHANGELOG.md | sed '1d'
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.latest_version }}
+          release_name: v${{ env.latest_version }}
+          body: "${{ env.release_details }}"
+          draft: false
+          prerelease: false 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,17 +10,13 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code  
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
 
       - name: Get version
-        run: |
-          git pull
-          latest_version=$(awk '/^## / { if (p) exit; p=1 } p' CHANGELOG.md | grep '##' | sed 's/## //')
-          if $(echo $latest_version | grep -q "(");then
-            latest_version=$(echo $latest_version | sed 's/\ (.*$//')
-          fi
-          echo "latest_version=$(echo $latest_version)" >> $GITHUB_ENV
+        run: echo "latest_version=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
 
       - name: Get details
         run: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,65 @@
+# This workflow will bump the version
+
+name: Bump version and update changelog
+
+on:
+  workflow_call:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  version_bump:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Configure Github Credentials
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check Changelog
+        run: |
+          if ! grep -i -q "## UNRELEASED" CHANGELOG.md; then
+            echo "Error: 'UNRELEASED' not found in CHANGELOG.md. Please ensure the changelog is correctly formatted."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Bump npm version
+        run: |
+          new_version=$(npm version ${{ inputs.version_type }})
+          echo "new_version=$(echo $new_version | sed 's/v//')" >> $GITHUB_ENV
+        
+      - name: Update changelog
+        run: |
+           today=$(date +'%Y-%m-%d')
+           sed -i "s/## unreleased/## ${{ env.new_version }} (${today})/i" CHANGELOG.md
+
+      - name: Commit and push changes
+        run: |
+          git tag -m  ${{ env.new_version }} ${{ env.new_version }}
+          git add --all
+          git commit -m "v${{ env.new_version }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 6.0.3
+
+- Fix a bug with not being able to remove handlers when targetFrames are used.
+
 ## 6.0.2
 
 - Update (sub-)dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "framebus",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "framebus",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "@braintree/uuid": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/braintree/framebus.git"
   },
   "homepage": "https://github.com/braintree/framebus",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "main": "dist/index.js",
   "files": [
     "dist/"


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
Adding/updating a series of Github Actions workflows to automate publishing to NPM. 

#### New:
- `version-bump.yml`
  - Automatically bumps npm version
  - Runs manually or via `publish.yml`
- `release-notes.yml`
  - Automatically creates a Github Release with notes
  - Runs manually or via `publish.yml`
- **`publish.yml`**
  - Does both of the above, runs `ci-unit-tests.yml` AND publishes package to npm
  - Runs manually but can be configured to run on merge to main
- `PULL_REQUEST_TEMPLATE.md`
  - A standardized template for PRs

#### Updated:
- `ci-functional-tests.yml`
  - Bumped `actions/setup-node` to v4
  - Updated to be more dynamic (read nvmrc for node version)
- `ci-unit-tests.yml`
  - Bumped `actions/setup-node` to v4
  - Updated to be more dynamic (read nvmrc for node version)


### Checklist

- ~Added a changelog entry~ *Changelog unnecessary—no functionality changes*

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @CJGlitter 

### Reviewers

@braintree/team-sdk-js 